### PR TITLE
Macos x

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -143,7 +143,7 @@ if ( NOT ${OMIT_MAIN_APP} )
         set( PLATFORM_LIBS "" )
     endif()
 
-    set(app_libs radiumGuiBase radiumEngine radiumCore ${Qt5_LIBRARIES} ${OPENGL_LIBRARIES} ${PLATFORM_LIBS})
+    set(app_libs radiumGuiBase radiumEngine radiumCore ${Qt5_LIBRARIES} ${OPENGL_LIBRARIES} ${PLATFORM_LIBS} ${ASSIMP_LIB})
 
     file(GLOB_RECURSE app_sources MainApplication/*.cpp)
     file(GLOB_RECURSE app_headers MainApplication/*.h MainApplication/*.hpp)

--- a/src/Engine/Renderer/RenderTechnique/ShaderProgram.cpp
+++ b/src/Engine/Renderer/RenderTechnique/ShaderProgram.cpp
@@ -18,20 +18,6 @@
 #include <Engine/Renderer/OpenGL/OpenGL.hpp>
 #include <Engine/Renderer/Texture/Texture.hpp>
 
-
-/*
- * Mathias : on MacOsX, interface matching between shaders somehow buggy ... Explanations here ...
- * https://www.opengl.org/wiki/Shader_Compilation#Before_linking
- * and here
- * https://www.opengl.org/wiki/Layout_Qualifier_(GLSL)
- * Note: The ARB_separate_shader_objects extension was released in a form where this kind of layout location linking outside of separate shaders did not work.
- * That is, if you specified location indices, they were effectively ignored unless you were linking a separate program.
- *
- * Remeber to re-declare "out gl_PerVertex  ..." in shaders with layout binding.
- *
- * TODO : be more rigourous thant this hack (like in ShaderObject::loadAndCompile and ShaderProgram::link)
- */
-
 namespace Ra
 {
     namespace Engine


### PR DESCRIPTION
Two things on this pull request : 
   enable compiling on macOsX with both clang and gcc
   solve shader compilation issue on MacOsX
On MacOsX,  inter-shaders stage communication with layout binding requires GL_PROGRAM_SEPARABLE. 
Explanations here : 
  https://www.opengl.org/wiki/Shader_Compilation#Before_linking
  https://www.opengl.org/wiki/Layout_Qualifier_(GLSL)