### PR TITLE
Fix Eigen's alignment problem with AVX

### DIFF
--- a/src/Core/Containers/AlignedStdVector.hpp
+++ b/src/Core/Containers/AlignedStdVector.hpp
@@ -3,18 +3,20 @@
 #include <Core/RaCore.hpp>
 
 #include <vector>
-#include <Core/Containers/AlignedAllocator.hpp>
+#include <Eigen/StdVector> 
 
 namespace Ra
 {
     namespace Core
     {
 
-        /// Shortcut for the ubiquitous 16-byte aligned std::vector
-        template <typename T, uint Align = 16>
-        class AlignedStdVector : public std::vector <T, AlignedAllocator <T, Align>>
+        /// Shortcut for the ubiquitous aligned std::vector
+        /// Uses Eigen's aligned allocator, as stated in 
+        /// http://eigen.tuxfamily.org/dox/group__TopicStlContainers.html
+        template <typename T>
+        class AlignedStdVector : public std::vector <T, Eigen::aligned_allocator<T>> 
         {
-            using std::vector<T, AlignedAllocator <T, Align>>::vector;
+            using std::vector<T, Eigen::aligned_allocator<T>>::vector;
         };
     }
 }

--- a/src/Core/Math/LinearAlgebra.hpp
+++ b/src/Core/Math/LinearAlgebra.hpp
@@ -226,6 +226,8 @@ namespace Ra
         // when declaring objects containing Vector or Matrices.
         // http://eigen.tuxfamily.org/dox-devel/group__TopicStructHavingEigenMembers.html
 #define  RA_CORE_ALIGNED_NEW EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+        /// Use this parameter for aligning structures with Eigen members in it
+#define  RA_DEFAULT_ALIGN EIGEN_MAX_ALIGN_BYTES
 
     }
 } // end namespace Ra::Core

--- a/src/Core/Utils/File/OBJFileManager.hpp
+++ b/src/Core/Utils/File/OBJFileManager.hpp
@@ -1,13 +1,13 @@
 #ifndef RADIUMENGINE_OBJ_FILE_MANAGER_HPP
 #define RADIUMENGINE_OBJ_FILE_MANAGER_HPP
-
+#include <Core/RaCore.hpp>
 #include <Core/Utils/File/FileManager.hpp>
 #include <Core/Mesh/TriangleMesh.hpp>
 
 namespace Ra {
 namespace Core {
 
-class OBJFileManager : public FileManager< TriangleMesh > {
+class RA_CORE_API OBJFileManager : public FileManager< TriangleMesh > {
 public:
     /// CONSTRUCTOR
     OBJFileManager();

--- a/src/Engine/Assets/HandleData.hpp
+++ b/src/Engine/Assets/HandleData.hpp
@@ -14,7 +14,10 @@ namespace Ra {
 namespace Asset {
 
 struct HandleComponentData {
+    RA_CORE_ALIGNED_NEW;
+
     HandleComponentData();
+
 
     Core::Transform                          m_frame;
     std::string                              m_name;

--- a/src/Engine/Assets/KeyFrame/KeyFrame.hpp
+++ b/src/Engine/Assets/KeyFrame/KeyFrame.hpp
@@ -4,6 +4,7 @@
 #include <map>
 #include <set>
 #include <Core/Containers/AlignedAllocator.hpp>
+#include <Core/Math/LinearAlgebra.hpp>
 #include <Engine/Assets/KeyFrame/AnimationTime.hpp>
 
 namespace Ra {
@@ -143,7 +144,7 @@ protected:
 protected:
     /// VARIABLE
     AnimationTime           m_time;
-    std::map < Time, FRAME, std::less<Time>, Ra::Core::AlignedAllocator<std::pair < Time, FRAME >, 16 > > m_keyframe;
+    std::map < Time, FRAME, std::less<Time>, Ra::Core::AlignedAllocator<std::pair < Time, FRAME >, RA_DEFAULT_ALIGN> > m_keyframe;
 };
 
 

--- a/src/Engine/Renderer/RenderTechnique/RenderParameters.hpp
+++ b/src/Engine/Renderer/RenderTechnique/RenderParameters.hpp
@@ -7,7 +7,7 @@
 #include <set>
 
 #include <Core/Math/LinearAlgebra.hpp>
-#include <Core/Containers/AlignedStdVector.hpp>
+#include <Core/Containers/AlignedAllocator.hpp>
 #include <Core/Log/Log.hpp>
 
 namespace Ra
@@ -60,7 +60,7 @@ namespace Ra
                 int m_texUnit;
             };
 
-            template <typename T> class UniformBindableVector : public std::map<std::string, T, std::less<std::string>, Core::AlignedAllocator<T,16> >
+            template <typename T> class UniformBindableVector : public std::map<std::string, T, std::less<std::string>, Core::AlignedAllocator<T, RA_DEFAULT_ALIGN> >
             {
             public:
                 void bind(const ShaderProgram* shader ) const;


### PR DESCRIPTION
Depending on your compiler flags, Eigen can now require as much as 32 bytes alignment (instead of 16 previously), if you use AVX extensions. 

So it's now required to align to `EIGEN_MAX_ALIGN_BYTES` for aligned allocators.
This bugs appeared only on windows so far (probably because malloc is better behaved on Linux and we don't have AVX enabled on Linux yet.
