### PR TITLE
Raycast & grid fix

### DIFF
--- a/Plugins/FancyMesh/src/FancyMeshComponent.cpp
+++ b/Plugins/FancyMesh/src/FancyMeshComponent.cpp
@@ -60,7 +60,7 @@ namespace FancyMeshPlugin
 
         std::string roName = name;
         roName.append( "_RO" );
-        
+
 #if 1
         std::string meshName = name;
         meshName.append( "_Mesh" );
@@ -217,18 +217,6 @@ namespace FancyMeshPlugin
     const Ra::Core::Index* FancyMeshComponent::roIndexRead() const
     {
         return &m_meshIndex;
-    }
-
-    void FancyMeshComponent::rayCastQuery( const Ra::Core::Ray& r) const
-    {
-        auto result  = Ra::Core::MeshUtils::castRay( getMesh(), r );
-        int tidx = result.m_hitTriangle;
-        if (tidx >= 0)
-        {
-            LOG(logINFO) << " Hit triangle " << tidx;
-            LOG(logINFO) << " Nearest vertex " << result.m_nearestVertex;
-            LOG(logINFO) << "Hit position : "<< r.pointAt( result.m_t ).transpose();
-        }
     }
 
 } // namespace FancyMeshPlugin

--- a/Plugins/FancyMesh/src/FancyMeshComponent.hpp
+++ b/Plugins/FancyMesh/src/FancyMeshComponent.hpp
@@ -32,7 +32,6 @@ namespace FancyMeshPlugin
 
 
         virtual void initialize() override;
-        virtual void rayCastQuery(const Ra::Core::Ray& r) const override;
 
         void addMeshRenderObject(const Ra::Core::TriangleMesh& mesh, const std::string& name);
         void handleMeshLoading(const Ra::Asset::GeometryData* data);

--- a/src/Core/Containers/Tex3D.inl
+++ b/src/Core/Containers/Tex3D.inl
@@ -32,7 +32,10 @@ namespace Ra
         inline T Tex3D<T>::fetch( const Vector3& v ) const
         {
             Vector3 scaled_coords( (v -  m_aabb.min() ).cwiseQuotient( m_cellSize ) );
-            Vector3 tmp = Vector::floor( scaled_coords );
+            // Sometimes due to float imprecision, a value of 0 is passed as -1e7
+            // which floors incorrectly rounds down to -1, hence the use of trunc().
+            Vector3 tmp = Vector::trunc( scaled_coords );
+            CORE_ASSERT( !((tmp.array() < Vector3::Zero().array()).any()), "Cannot cast to uint");
             Vector3ui nearest = tmp.cast<uint>();
 
             Vector3 fact = scaled_coords - Vector3( nearest[0], nearest[1], nearest[2] ) ;

--- a/src/Core/Math/LinearAlgebra.hpp
+++ b/src/Core/Math/LinearAlgebra.hpp
@@ -130,6 +130,7 @@ namespace Ra
         //
         namespace Vector
         {
+
             /// Component-wise floor() function on a floating-point vector.
             template<typename Vector>
             inline Vector floor( const Vector& v );
@@ -137,6 +138,10 @@ namespace Ra
             /// Component-wise ceil() function on a floating-point vector.
             template<typename Vector>
             inline Vector ceil( const Vector& v );
+
+            /// Component-wise trunc() function on a floating-point vector
+            template<typename Vector>
+            inline Vector trunc( const Vector& v );
 
             /// Component-wise clamp() function on a floating-point vector.
             template<typename Vector>

--- a/src/Core/Math/LinearAlgebra.inl
+++ b/src/Core/Math/LinearAlgebra.inl
@@ -32,6 +32,13 @@ namespace Core
     }
 
     template<typename Vector_>
+    inline Vector_ Vector::trunc( const Vector_& v )
+    {
+        typedef typename Vector_::Scalar Scalar_;
+        return v.unaryExpr( std::function<Scalar_( Scalar_ )> ( static_cast<Scalar_( & )( Scalar_ )> ( std::trunc) ) );
+    }
+
+    template<typename Vector_>
     inline Vector_ Vector::clamp( const Vector_& v, const Vector_& min, const Vector_& max )
     {
         return v.cwiseMin( max ).cwiseMax( min );
@@ -182,15 +189,15 @@ namespace Core
 
         inline Matrix4 perspective(Scalar fovy, Scalar aspect, Scalar znear, Scalar zfar)
         {
-            Scalar theta = fovy * 0.5;
+            Scalar theta = fovy * 0.5f;
             Scalar range = zfar - znear;
-            Scalar invtan = 1.0 / std::tan(theta);
+            Scalar invtan = 1.f / std::tan(theta);
 
             Matrix4 result = Matrix4::Zero();
             result(0, 0) = invtan / aspect;
             result(1, 1) = invtan;
             result(2, 2) = -(znear + zfar) / range;
-            result(3, 2) = -1.0;
+            result(3, 2) = -1.f;
             result(2, 3) = -2 * znear * zfar / range;
             result(3, 3) = 0.0;
 
@@ -201,10 +208,10 @@ namespace Core
         {
             Matrix4 result = Matrix4::Zero();
 
-            result(0, 0) =  2.0 / (r - l);
-            result(1, 1) =  2.0 / (t - b);
-            result(2, 2) = -2.0 / (f - n);
-            result(3, 3) =  1.0;
+            result(0, 0) =  2.f / (r - l);
+            result(1, 1) =  2.f / (t - b);
+            result(2, 2) = -2.f / (f - n);
+            result(3, 3) =  1.f;
 
             result(0, 3) = -(r + l) / (r - l);
             result(1, 3) = -(t + b) / (t - b);

--- a/src/Engine/Component/Component.cpp
+++ b/src/Engine/Component/Component.cpp
@@ -60,20 +60,27 @@ namespace Ra
         {
             for (const auto& idx : m_renderObjects)
             {
-
                 const auto ro = getRoMgr()->getRenderObject(idx);
-                const Ra::Core::Transform& t = ro->getLocalTransform();
-                Core::Ray transformedRay = Ra::Core::transformRay(ray, t.inverse());
-                auto result  = Ra::Core::MeshUtils::castRay( ro->getMesh()->getGeometry(), ray );
-                const int& tidx = result.m_hitTriangle;
-                if (tidx >= 0)
+                if (ro->isVisible())
                 {
-                    LOG(logINFO) << " Ray cast vs "<<ro->getName();
-                    LOG(logINFO) << " Hit triangle " << tidx;
-                    LOG(logINFO) << " Nearest vertex " << result.m_nearestVertex;
-                    LOG(logINFO) << "Hit position (RO): "<< ray.pointAt( result.m_t ).transpose();
-                    LOG(logINFO) << "Hit position (Comp): "<< (t * ray.pointAt( result.m_t )).transpose();
-                    LOG(logINFO) << "Hit position (World): "<< (getEntity()->getTransform() * t * ray.pointAt( result.m_t )).transpose();
+                    const Ra::Core::Transform& t = ro->getLocalTransform();
+                    Core::Ray transformedRay = Ra::Core::transformRay(ray, t.inverse());
+                    auto result = Ra::Core::MeshUtils::castRay(ro->getMesh()->getGeometry(), transformedRay);
+                    const int& tidx = result.m_hitTriangle;
+                    if (tidx >= 0)
+                    {
+
+                        const Ra::Core::Vector3 pLocal = transformedRay.pointAt(result.m_t);
+                        const Ra::Core::Vector3 pEntity = t * pLocal;
+                        const Ra::Core::Vector3 pWorld = getEntity()->getTransform() * pEntity;
+
+                        LOG(logINFO) << " Ray cast vs " << ro->getName();
+                        LOG(logINFO) << " Hit triangle " << tidx;
+                        LOG(logINFO) << " Nearest vertex " << result.m_nearestVertex;
+                        LOG(logINFO) << "Hit position (RO): " << pLocal.transpose();
+                        LOG(logINFO) << "Hit position (Comp): " << pEntity.transpose();
+                        LOG(logINFO) << "Hit position (World): " << pWorld.transpose();
+                    }
                 }
             }
 

--- a/src/Engine/Component/Component.cpp
+++ b/src/Engine/Component/Component.cpp
@@ -55,5 +55,28 @@ namespace Ra
                 m_renderObjects.erase( found );
             }
         }
+
+        void Component::rayCastQuery(const Core::Ray& ray) const
+        {
+            for (const auto& idx : m_renderObjects)
+            {
+
+                const auto ro = getRoMgr()->getRenderObject(idx);
+                const Ra::Core::Transform& t = ro->getLocalTransform();
+                Core::Ray transformedRay = Ra::Core::transformRay(ray, t.inverse());
+                auto result  = Ra::Core::MeshUtils::castRay( ro->getMesh()->getGeometry(), ray );
+                const int& tidx = result.m_hitTriangle;
+                if (tidx >= 0)
+                {
+                    LOG(logINFO) << " Ray cast vs "<<ro->getName();
+                    LOG(logINFO) << " Hit triangle " << tidx;
+                    LOG(logINFO) << " Nearest vertex " << result.m_nearestVertex;
+                    LOG(logINFO) << "Hit position (RO): "<< ray.pointAt( result.m_t ).transpose();
+                    LOG(logINFO) << "Hit position (Comp): "<< (t * ray.pointAt( result.m_t )).transpose();
+                    LOG(logINFO) << "Hit position (World): "<< (getEntity()->getTransform() * t * ray.pointAt( result.m_t )).transpose();
+                }
+            }
+
+        }
     }
 } // namespace Ra

--- a/src/Engine/Component/Component.hpp
+++ b/src/Engine/Component/Component.hpp
@@ -72,7 +72,7 @@ namespace Ra
             virtual void removeRenderObject( Core::Index roIdx ) final;
 
             /// Perform a ray cast query.
-            virtual void rayCastQuery(const Core::Ray& ray) const  {}
+            virtual void rayCastQuery(const Core::Ray& ray) const;
 
             // Editable transform interface.
             // This allow to edit the data in the component with a render object

--- a/src/Engine/Entity/Entity.hpp
+++ b/src/Engine/Entity/Entity.hpp
@@ -67,7 +67,7 @@ namespace Ra
             inline uint getNumComponents() const;
 
             // Queries
-            void rayCastQuery(const Core::Ray& r) const;
+            virtual void rayCastQuery(const Core::Ray& r) const;
 
         private:
             Core::Transform m_transform;

--- a/src/Engine/Managers/SystemDisplay/SystemDisplay.hpp
+++ b/src/Engine/Managers/SystemDisplay/SystemDisplay.hpp
@@ -49,12 +49,15 @@ namespace Ra
         /// It should have only one component and its transform should not change.
         class RA_ENGINE_API SystemEntity : public Entity
         {
-            RA_SINGLETON_INTERFACE(SystemEntity);
+        RA_SINGLETON_INTERFACE(SystemEntity);
 
         public:
             SystemEntity();
 
-            virtual ~SystemEntity() { };
+            virtual ~SystemEntity() {};
+
+            /// Ignore raycast queries
+            virtual void rayCastQuery(const Core::Ray& r) const override{}
 
 #ifndef RA_DISABLE_DEBUG_DISPLAY
             /// Access the debug component


### PR DESCRIPTION
This change set has two parts.

The first two commits upgrade the raycast query which is used to query a scene from the GUI (pretty useful to get location of problematic points, vertices or triangles).
By default, the behaviour  of each component is to raycast versus all components visible render objects meshes, while it used to be only available in Fancy Mesh component.
It now  prints the intersection point in all frames of reference.

The last commit fixes a bug in the grid implementation which would happen when small negative values would be passed where 0 was expected due to floating point imprecision.
In this case the result was floored and then casted to uint which gave wrong high integer values.
The fix was to used the function `ceil()` instead of `floor()`, and add an assert to catch other instances of this issue.