### PR TITLE
String test and asset loading fix

### DIFF
--- a/src/Core/String/StringUtils.cpp
+++ b/src/Core/String/StringUtils.cpp
@@ -25,7 +25,7 @@ namespace Ra
             {
                 std::string res;
                 ulong pos = str.find_last_of( '.' );
-                res = pos + 1 < str.size()? str.substr( pos + 1 ) : "";
+                res = pos != std::string::npos ? str.substr( pos + 1 ) : "";
                 return res;
             }
 

--- a/src/Engine/Assets/AssimpGeometryDataLoader.cpp
+++ b/src/Engine/Assets/AssimpGeometryDataLoader.cpp
@@ -268,13 +268,13 @@ namespace Ra {
             const uint size = mesh.mNumVertices;
             std::vector<Core::Vector3> normal(data.getVerticesSize(), Core::Vector3::Zero());
 #pragma omp parallel for
-            for( int i = 0; i < int(size); ++i ) 
+            for( int i = 0; i < int(size); ++i )
             {
                 normal.at( data.m_duplicateTable.at( i ) ) += assimpToCore( mesh.mNormals[i] );
             }
 
 #pragma omp parallel for
-            for( int i = 0; i < int(normal.size()); ++i ) 
+            for( int i = 0; i < int(normal.size()); ++i )
             {
                 normal[i].normalize();
             }
@@ -286,7 +286,7 @@ namespace Ra {
             const uint size = mesh.mNumVertices;
             std::vector<Core::Vector3> tangent(data.getVerticesSize(), Core::Vector3::Zero());
 #pragma omp parallel for
-            for( uint i = 0; i < size; ++i ) 
+            for( uint i = 0; i < size; ++i )
             {
                 tangent[i] = assimpToCore( mesh.mTangents[i]);
             }
@@ -299,7 +299,7 @@ namespace Ra {
             const uint size = mesh.mNumVertices;
             std::vector<Core::Vector3> bitangent(data.getVerticesSize());
 #pragma omp parallel for
-            for( uint i = 0; i < size; ++i ) 
+            for( uint i = 0; i < size; ++i )
             {
                 bitangent[i] = assimpToCore(mesh.mBitangents[i]);
             }
@@ -331,7 +331,7 @@ namespace Ra {
         {
 #if 0
             GeometryData::WeightArray weights(data.getVerticesSize());
-            
+
             for (uint i = 0; i < mesh.mNumBones; ++i)
             {
                 aiBone* bone = mesh.mBones[i];
@@ -349,7 +349,7 @@ namespace Ra {
             data.setWeights(weights);
 #endif
         }
-    
+
         void AssimpGeometryDataLoader::loadMaterial( const aiMaterial& material, GeometryData& data ) const {
 
             MaterialData mat;

--- a/src/Engine/Assets/AssimpWrapper.hpp
+++ b/src/Engine/Assets/AssimpWrapper.hpp
@@ -53,7 +53,8 @@ namespace Ra {
         }
 
         inline std::string assimpToCore( const aiString& string ) {
-            return std::string( string.C_Str() );
+            std::string result ( string.C_Str() );
+            return result.empty() ? "default" : result;
         }
 
         inline Core::VectorNi assimpToCore( uint* index, const uint size )

--- a/src/Tests/CoreTests/String/StringTest.hpp
+++ b/src/Tests/CoreTests/String/StringTest.hpp
@@ -1,0 +1,80 @@
+#ifndef RADIUM_STRINGTESTS_HPP_
+#define RADIUM_STRINGTESTS_HPP_
+
+
+#include <Tests/CoreTests/Tests.hpp>
+#include <Core/String/StringUtils.hpp>
+
+namespace RaTests
+{
+    class StringTests : public Test
+    {
+        void run() override
+        {
+
+            using Ra::Core::StringUtils::getFileExt;
+            using Ra::Core::StringUtils::getDirName;
+            using Ra::Core::StringUtils::getBaseName;
+
+            // Test getFileExt
+            {
+                RA_UNIT_TEST(getFileExt("aaa.xyz") == std::string("xyz"), "File extension");
+                RA_UNIT_TEST(getFileExt("aaa/bbb.xyz") == std::string("xyz"), "Extension of relative path");
+                RA_UNIT_TEST(getFileExt("/aaa/bbb/ccc.xyz") == std::string("xyz"), "Extension of absolute path");
+                RA_UNIT_TEST(getFileExt("aaa/bbb/xyz") == std::string(""), "File with no extension");
+                RA_UNIT_TEST(getFileExt("aaa/bbb/xyz.") == std::string(""), "File with no extension");
+            }
+
+
+            // Test getDirName
+            {
+                RA_UNIT_TEST(getDirName("aaa.xyz") == std::string("."), "File with no directory");
+                RA_UNIT_TEST(getDirName("aaa/bbb.xyz") == std::string("aaa"), "Relative path");
+                RA_UNIT_TEST(getDirName("/aaa/bbb/ccc.xyz") == std::string("/aaa/bbb"), "Absolute path");
+                RA_UNIT_TEST(getDirName("/aaa/bbb/ccc.xyz///") == std::string("/aaa/bbb"), "Trailing slashes");
+                RA_UNIT_TEST(getDirName("aaa/bbb/xyz") == std::string("aaa/bbb"), "File with no extension");
+            }
+
+            // Test getBaseName
+            {
+                RA_UNIT_TEST(getBaseName("aaa.xyz", true) == std::string("aaa.xyz"), "File with no directory");
+                RA_UNIT_TEST(getBaseName("aaa.xyz", false) == std::string("aaa"), "File with no directory");
+                RA_UNIT_TEST(getBaseName("aaa/bbb.xyz", true) == std::string("bbb.xyz"), "Relative path");
+                RA_UNIT_TEST(getBaseName("aaa/bbb.xyz", false) == std::string("bbb"), "Relative path");
+                RA_UNIT_TEST(getBaseName("/aaa/bbb/ccc.xyz", true) == std::string("ccc.xyz"), "Absolute path");
+                RA_UNIT_TEST(getBaseName("/aaa/bbb/ccc.xyz", false) == std::string("ccc"), "Absolute path");
+                RA_UNIT_TEST(getBaseName("/aaa/bbb/ccc.xyz///", false) == std::string("ccc"), "Trailing slashes");
+                RA_UNIT_TEST(getBaseName("aaa/bbb/xyz", true) == std::string("xyz"), "File with no extension");
+                RA_UNIT_TEST(getBaseName("aaa/bbb/xyz", false) == std::string("xyz"), "File with no extension");
+            }
+
+            std::string path = "/aaa/bbb/ccc.xyz";
+            RA_UNIT_TEST( getDirName(path)+"/"+getBaseName( path, false)+"."+getFileExt(path) == path, "Path reconstruction" );
+
+            // Test string printf
+            using Ra::Core::StringUtils::stringPrintf;
+
+            const char* format = "test %u test %p test %f";
+            char buffer[100];
+            memset(buffer, 0x0, 100);
+            std::string str;
+
+
+            int v1 = sprintf(buffer, format, 42, this, 3.14);
+            int v2 = stringPrintf( str, format, 42, this, 3.14);
+            RA_UNIT_TEST( v1 == v2 && str == std::string(buffer), "String printf");
+
+
+
+
+
+
+
+        }
+    };
+    RA_TEST_CLASS(StringTests);
+}
+
+
+
+#endif //RADIUM_ALGEBRATESTS_HPP_

--- a/src/Tests/CoreTests/String/StringTest.hpp
+++ b/src/Tests/CoreTests/String/StringTest.hpp
@@ -59,17 +59,9 @@ namespace RaTests
             memset(buffer, 0x0, 100);
             std::string str;
 
-
             int v1 = sprintf(buffer, format, 42, this, 3.14);
             int v2 = stringPrintf( str, format, 42, this, 3.14);
             RA_UNIT_TEST( v1 == v2 && str == std::string(buffer), "String printf");
-
-
-
-
-
-
-
         }
     };
     RA_TEST_CLASS(StringTests);

--- a/src/Tests/CoreTests/main.cpp
+++ b/src/Tests/CoreTests/main.cpp
@@ -3,6 +3,7 @@
 #include <Tests/CoreTests/Algebra/AlgebraTests.hpp>
 #include <Tests/CoreTests/Geometry/GeometryTests.hpp>
 #include <Tests/CoreTests/RayCasts/RayCastTest.hpp>
+#include <Tests/CoreTests/String/StringTest.hpp>
 
 int main()
 {


### PR DESCRIPTION
This PR includes two commits :
* a unit test  for `Core::StringUtils` and a fix for the bug it helped to catch
* A fix to asset loading which would give a default name to unnamed meshes in assimp, which could cause problems for skinning setup.