### PR TITLE
Remove dynamic_cast and replace by fetch in system's map for componen…

### DIFF
--- a/Plugins/Skinning/src/SkinningComponent.hpp
+++ b/Plugins/Skinning/src/SkinningComponent.hpp
@@ -15,14 +15,8 @@
 
 namespace SkinningPlugin
 {
-    class SkinningPluginC;
-}
-
-namespace SkinningPlugin
-{
     class SKIN_PLUGIN_API SkinningComponent : public Ra::Engine::Component
     {
-        friend class SkinningPlugin::SkinningPluginC;
     public:
 
         enum SkinningType

--- a/Plugins/Skinning/src/SkinningComponent.hpp
+++ b/Plugins/Skinning/src/SkinningComponent.hpp
@@ -13,11 +13,16 @@
 #include <Engine/Component/Component.hpp>
 #include <Engine/Managers/ComponentMessenger/ComponentMessenger.hpp>
 
+namespace SkinningPlugin
+{
+    class SkinningPluginC;
+}
 
 namespace SkinningPlugin
 {
     class SKIN_PLUGIN_API SkinningComponent : public Ra::Engine::Component
     {
+        friend class SkinningPlugin::SkinningPluginC;
     public:
 
         enum SkinningType

--- a/Plugins/Skinning/src/SkinningPlugin.cpp
+++ b/Plugins/Skinning/src/SkinningPlugin.cpp
@@ -73,11 +73,10 @@ namespace SkinningPlugin
         Ra::Engine::ItemEntry it = m_selectionManager->currentItem();
         if (it.m_entity)
         {
-            auto comp = std::find_if( m_system->m_components.begin(), m_system->m_components.end(),
-                                      [it](const auto& ec){return ec.first == it.m_entity;});
-            if (comp != m_system->m_components.end())
+            auto comps = m_system->getEntityComponents( it.m_entity );
+            if (comps.size() != 0)
             {
-                m_widget->setCurrent(it, static_cast<SkinningPlugin::SkinningComponent*>(comp->second));
+                m_widget->setCurrent(it, static_cast<SkinningPlugin::SkinningComponent*>(comps[0]));
             }
             else
             {

--- a/Plugins/Skinning/src/SkinningPlugin.cpp
+++ b/Plugins/Skinning/src/SkinningPlugin.cpp
@@ -73,17 +73,13 @@ namespace SkinningPlugin
         Ra::Engine::ItemEntry it = m_selectionManager->currentItem();
         if (it.m_entity)
         {
-            bool found = false;
-            for (auto ec : m_system->m_components)
+            auto comp = std::find_if( m_system->m_components.begin(), m_system->m_components.end(),
+                                      [it](const auto& ec){return ec.first == it.m_entity;});
+            if (comp != m_system->m_components.end())
             {
-                if (ec.first == it.m_entity)
-                {
-                    m_widget->setCurrent(it, static_cast<SkinningPlugin::SkinningComponent*>(ec.second));
-                    found = true;
-                    break;
-                }
+                m_widget->setCurrent(it, static_cast<SkinningPlugin::SkinningComponent*>(comp->second));
             }
-            if (!found)
+            else
             {
                 m_widget->setCurrent(it, nullptr);
             }

--- a/Plugins/Skinning/src/SkinningPlugin.cpp
+++ b/Plugins/Skinning/src/SkinningPlugin.cpp
@@ -73,18 +73,17 @@ namespace SkinningPlugin
         Ra::Engine::ItemEntry it = m_selectionManager->currentItem();
         if (it.m_entity)
         {
-            const std::vector< std::unique_ptr<Ra::Engine::Component> >& comps = it.m_entity->getComponents();
-            size_t i = 0;
-            for ( ; i<comps.size(); ++i)
+            bool found = false;
+            for (auto ec : m_system->m_components)
             {
-                auto skinComp = dynamic_cast<SkinningPlugin::SkinningComponent*>(comps[i].get());
-                if(skinComp)
+                if (ec.first == it.m_entity)
                 {
-                    m_widget->setCurrent(it, static_cast<SkinningComponent*>(skinComp));
+                    m_widget->setCurrent(it, static_cast<SkinningPlugin::SkinningComponent*>(ec.second));
+                    found = true;
                     break;
                 }
             }
-            if (i >= comps.size())
+            if (!found)
             {
                 m_widget->setCurrent(it, nullptr);
             }

--- a/Plugins/Skinning/src/SkinningSystem.hpp
+++ b/Plugins/Skinning/src/SkinningSystem.hpp
@@ -17,9 +17,15 @@
 
 namespace SkinningPlugin
 {
+    class SkinningPluginC;
+}
+
+namespace SkinningPlugin
+{
 
     class SKIN_PLUGIN_API SkinningSystem :  public Ra::Engine::System
     {
+        friend class SkinningPlugin::SkinningPluginC;
     public:
         SkinningSystem(){}
         virtual void generateTasks( Ra::Core::TaskQueue* taskQueue,

--- a/Plugins/Skinning/src/SkinningSystem.hpp
+++ b/Plugins/Skinning/src/SkinningSystem.hpp
@@ -17,15 +17,9 @@
 
 namespace SkinningPlugin
 {
-    class SkinningPluginC;
-}
-
-namespace SkinningPlugin
-{
 
     class SKIN_PLUGIN_API SkinningSystem :  public Ra::Engine::System
     {
-        friend class SkinningPlugin::SkinningPluginC;
     public:
         SkinningSystem(){}
         virtual void generateTasks( Ra::Core::TaskQueue* taskQueue,

--- a/src/Engine/System/System.cpp
+++ b/src/Engine/System/System.cpp
@@ -59,5 +59,18 @@ namespace Ra
                 m_components.erase( pos );
             }
         }
+
+        std::vector< Component* > System::getEntityComponents( const Entity* entity )
+        {
+            std::vector< Component* > comps;
+            for (const auto& ec : m_components)
+            {
+                if (ec.first == entity)
+                {
+                    comps.push_back( ec.second );
+                }
+            }
+            return comps;
+        }
     }
 } // namespace Ra

--- a/src/Engine/System/System.hpp
+++ b/src/Engine/System/System.hpp
@@ -71,6 +71,8 @@ namespace Ra
             /// Removes all components belonging to a given entity.
             void unregisterAllComponents( const Entity* entity );
 
+            /// Returns the components stored for the given entity.
+            std::vector< Component* > getEntityComponents( const Entity* entity );
 
             /**
              * Factory method for component creation from file data.
@@ -81,7 +83,7 @@ namespace Ra
 
         protected:
             /// List of active components.
-            std::vector<std::pair< const Entity*, Component*> > m_components;
+            std::vector< std::pair<const Entity*, Component*> > m_components;
         };
 
     } // namespace Engine


### PR DESCRIPTION
…ts ;

This was here to have a more fluid GUI regarding selection of object parts.
For example, after posing a character, one needed to specifically select the SkinningComponent from the tree view to be able to change the Skinning method, then select the animation skeleton again to change the pose.