### PR TITLE
Fix gizmo deadlock

### DIFF
--- a/Applications/MainApplication/Gui/MainWindow.cpp
+++ b/Applications/MainApplication/Gui/MainWindow.cpp
@@ -475,7 +475,7 @@ namespace Ra
         // the gizmos ROs to disappear, but the RO mutex is already acquired by the call for
         // the object we want to delete, which causes a deadlock.
         // Clearing the selection before deleting the object will avoid this problem.
-        m_selectionManager->clearSelection();
+        m_selectionManager->clear();
         if (e.isRoNode())
         {
             e.m_component->removeRenderObject(e.m_roIndex);


### PR DESCRIPTION
This fixes a bug that happened in the following condition :
* two or more entity presents
* select an entity
* activate the gizmos
* delete the entity

This created a deadlock in the entity deletion code as the following
scenario happens:

* the entity is deleted
* it triggers its removal from the item model
* because an object was "current object" in the tree view, this triggers
the tree view to select the next object available
* this causes the gizmos to try to spawn for the new object, which
is impossible because we are in the middle of a deletion.

This problem was supposedly fixed in #153 but only incorrectly : this is
because the clearSelection() method of ItemSelectionModel clears the
'selected' items but not the 'current' items. This is fixed by the use
of clear().