### PR TITLE
Val fixes

### DIFF
--- a/Applications/MainApplication/Gui/MainWindow.cpp
+++ b/Applications/MainApplication/Gui/MainWindow.cpp
@@ -111,6 +111,7 @@ namespace Ra
         connect(m_exportMeshButton, &QPushButton::clicked, this, &MainWindow::exportCurrentMesh);
         connect(m_removeEntityButton, &QPushButton::clicked, this, &MainWindow::deleteCurrentItem);
         connect(m_clearSceneButton, &QPushButton::clicked, this, &MainWindow::resetScene);
+        connect(m_fitCameraButton, &QPushButton::clicked, this, &MainWindow::fitCamera);
 
         // Renderer stuff
 
@@ -529,6 +530,11 @@ namespace Ra
         actionForward->setChecked( false );
         actionDeferred->setChecked( false );
         actionDeferred->setChecked( true );
+    }
+
+    void Gui::MainWindow::fitCamera()
+    {
+        m_viewer->fitCameraToScene(Engine::RadiumEngine::getInstance()->getRenderObjectManager()->getSceneAabb());
     }
 
 } // namespace Ra

--- a/Applications/MainApplication/Gui/MainWindow.cpp
+++ b/Applications/MainApplication/Gui/MainWindow.cpp
@@ -11,9 +11,6 @@
 #include <Engine/Managers/EntityManager/EntityManager.hpp>
 
 #include <Engine/Renderer/RenderTechnique/RenderTechnique.hpp>
-#include <Engine/Renderer/RenderTechnique/ShaderConfigFactory.hpp>
-#include <Engine/Renderer/RenderObject/RenderObjectManager.hpp>
-#include <Engine/Renderer/RenderObject/RenderObject.hpp>
 #include <Engine/Renderer/Mesh/Mesh.hpp>
 
 #include <Engine/Entity/Entity.hpp>
@@ -21,7 +18,6 @@
 #include <PluginBase/RadiumPluginInterface.hpp>
 
 #include <GuiBase/Viewer/CameraInterface.hpp>
-#include <GuiBase/TreeModel/EntityTreeModel.hpp>
 
 #include <Gui/MaterialEditor.hpp>
 
@@ -131,6 +127,9 @@ namespace Ra
         connect(m_enablePostProcess, &QCheckBox::stateChanged, m_viewer, &Viewer::enablePostProcess);
         connect(m_enableDebugDraw,   &QCheckBox::stateChanged, m_viewer, &Viewer::enableDebugDraw);
         connect(m_realFrameRate,     &QCheckBox::stateChanged, mainApp,  &BaseApplication::setRealFrameRate);
+
+        connect(m_printGraph,       &QCheckBox::stateChanged, mainApp,  &BaseApplication::setRecordGraph);
+        connect(m_printTimings,     &QCheckBox::stateChanged, mainApp,  &BaseApplication::setRecordTimings);
 
         // Connect engine signals to the appropriate callbacks
         std::function<void(const Engine::ItemEntry&)> add = std::bind(&MainWindow::onItemAdded, this, std::placeholders::_1);

--- a/Applications/MainApplication/Gui/MainWindow.hpp
+++ b/Applications/MainApplication/Gui/MainWindow.hpp
@@ -94,6 +94,9 @@ namespace Ra
             /// Slot for the "visible" button
             void toggleVisisbleRO();
 
+            /// Reset the camera to see all visible objects
+            void fitCamera();
+
             /// Slot for the "edit" button.
             void editRO();
 

--- a/Applications/MainApplication/Gui/ui/MainWindow.ui
+++ b/Applications/MainApplication/Gui/ui/MainWindow.ui
@@ -447,6 +447,27 @@
                </layout>
               </item>
               <item>
+               <layout class="QHBoxLayout" name="horizontalLayout">
+                <property name="bottomMargin">
+                 <number>0</number>
+                </property>
+                <item>
+                 <widget class="QCheckBox" name="m_printGraph">
+                  <property name="text">
+                   <string>Print Graph</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="m_printTimings">
+                  <property name="text">
+                   <string>Print Timings</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+              <item>
                <spacer name="verticalSpacer">
                 <property name="orientation">
                  <enum>Qt::Vertical</enum>
@@ -465,36 +486,6 @@
              <attribute name="title">
               <string>Edition</string>
              </attribute>
-            </widget>
-            <widget class="QWidget" name="tab_renderers">
-             <attribute name="title">
-              <string>Renderers</string>
-             </attribute>
-             <layout class="QHBoxLayout" name="horizontalLayout_2">
-              <item>
-               <widget class="QLabel" name="label_3">
-                <property name="text">
-                 <string>Current renderer :</string>
-                </property>
-                <layout class="QHBoxLayout" name="horizontalLayout">
-                 <item>
-                  <widget class="QCheckBox" name="m_printGraph">
-                   <property name="text">
-                    <string>Print Graph</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QCheckBox" name="m_printTimings">
-                   <property name="text">
-                    <string>Print timings</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-             </layout>
             </widget>
            </widget>
           </item>
@@ -737,6 +728,39 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+O</string>
+   </property>
+  </action>
+  <action name="actionForward">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Forward</string>
+   </property>
+  </action>
+  <action name="actionDeferred">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Deferred</string>
+   </property>
+  </action>
+  <action name="actionExperimental">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Experimental</string>
    </property>
   </action>
  </widget>

--- a/Applications/MainApplication/Gui/ui/MainWindow.ui
+++ b/Applications/MainApplication/Gui/ui/MainWindow.ui
@@ -459,6 +459,36 @@
               <string>Edition</string>
              </attribute>
             </widget>
+            <widget class="QWidget" name="tab_renderers">
+             <attribute name="title">
+              <string>Renderers</string>
+             </attribute>
+             <layout class="QHBoxLayout" name="horizontalLayout_2">
+              <item>
+               <widget class="QLabel" name="label_3">
+                <property name="text">
+                 <string>Current renderer :</string>
+                </property>
+                <layout class="QHBoxLayout" name="horizontalLayout">
+                 <item>
+                  <widget class="QCheckBox" name="m_printGraph">
+                   <property name="text">
+                    <string>Print Graph</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QCheckBox" name="m_printTimings">
+                   <property name="text">
+                    <string>Print timings</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+             </layout>
+            </widget>
            </widget>
           </item>
          </layout>
@@ -700,39 +730,6 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+O</string>
-   </property>
-  </action>
-  <action name="actionForward">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="checked">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Forward</string>
-   </property>
-  </action>
-  <action name="actionDeferred">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="enabled">
-    <bool>false</bool>
-   </property>
-   <property name="text">
-    <string>Deferred</string>
-   </property>
-  </action>
-  <action name="actionExperimental">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="enabled">
-    <bool>false</bool>
-   </property>
-   <property name="text">
-    <string>Experimental</string>
    </property>
   </action>
  </widget>

--- a/Applications/MainApplication/Gui/ui/MainWindow.ui
+++ b/Applications/MainApplication/Gui/ui/MainWindow.ui
@@ -175,6 +175,13 @@
                 </property>
                </widget>
               </item>
+              <item row="1" column="2">
+               <widget class="QPushButton" name="m_fitCameraButton">
+                <property name="text">
+                 <string>Fit Camera</string>
+                </property>
+               </widget>
+              </item>
              </layout>
             </item>
            </layout>

--- a/Applications/MainApplication/MainApplication.cpp
+++ b/Applications/MainApplication/MainApplication.cpp
@@ -70,18 +70,20 @@ namespace Ra
         parser.addVersionOption();
 
         QCommandLineOption fpsOpt(QStringList{"r", "framerate", "fps"}, "Control the application framerate, 0 to disable it (and run as fast as possible).", "number", "60");
+        QCommandLineOption maxThreadsOpt(QStringList{"m", "maxthreads", "max-threads"}, "Control the maximum number of threads. 0 will set to the number of cores available", "number", "0");
         QCommandLineOption numFramesOpt(QStringList{"n", "numframes"}, "Run for a fixed number of frames.", "number", "0");
         QCommandLineOption pluginOpt(QStringList{"p", "plugins", "pluginsPath"}, "Set the path to the plugin dlls.", "folder", "Plugins");
         QCommandLineOption pluginLoadOpt(QStringList{"l", "load", "loadPlugin"}, "Only load plugin with the given name (filename without the extension). If this option is not used, all plugins in the plugins folder will be loaded. ", "name");
         QCommandLineOption pluginIgnoreOpt(QStringList{"i", "ignore", "ignorePlugin"}, "Ignore plugins with the given name. If the name appears within both load and ignore options, it will be ignored.", "name");
         QCommandLineOption fileOpt(QStringList{"f", "file", "scene"}, "Open a scene file at startup.", "file name", "foo.bar");
 
-        parser.addOptions({fpsOpt, pluginOpt, pluginLoadOpt, pluginIgnoreOpt, fileOpt, numFramesOpt });
+        parser.addOptions({fpsOpt, pluginOpt, pluginLoadOpt, pluginIgnoreOpt, fileOpt, maxThreadsOpt, numFramesOpt });
         parser.process(*this);
 
         if (parser.isSet(fpsOpt))       m_targetFPS = parser.value(fpsOpt).toUInt();
         if (parser.isSet(pluginOpt))    pluginsPath = parser.value(pluginOpt).toStdString();
         if (parser.isSet(numFramesOpt)) m_numFrames = parser.value(numFramesOpt).toUInt();
+        if (parser.isSet(maxThreadsOpt)) m_maxThreads = parser.value(maxThreadsOpt).toUInt();
 
         // Boilerplate print.
         LOG( logINFO ) << "*** Radium Engine Main App  ***";
@@ -146,6 +148,7 @@ namespace Ra
         // initialized the OpenGL context..)
         processEvents();
 
+        Ra::Engine::RadiumEngine::getInstance()->getEntityManager()->createEntity("Test");
         // Load plugins
         if ( !loadPlugins( pluginsPath, parser.values(pluginLoadOpt), parser.values(pluginIgnoreOpt) ) )
         {
@@ -157,7 +160,12 @@ namespace Ra
         CORE_ASSERT( m_viewer->context()->isValid(), "OpenGL was not initialized" );
 
         // Create task queue with N-1 threads (we keep one for rendering).
-        m_taskQueue.reset( new Core::TaskQueue( std::thread::hardware_concurrency() - 1 ) );
+        uint numThreads =  std::thread::hardware_concurrency() - 1;
+        if (m_maxThreads > 0 && m_maxThreads < numThreads)
+        {
+            numThreads = m_maxThreads;
+        }
+        m_taskQueue.reset( new Core::TaskQueue(numThreads) );
 
         // Create the instance of the keymapping manager (should it be done here ?)
         Gui::KeyMappingManager::createInstance();

--- a/Applications/MainApplication/MainApplication.cpp
+++ b/Applications/MainApplication/MainApplication.cpp
@@ -53,6 +53,8 @@ namespace Ra
         , m_numFrames( 0 )
         , m_realFrameRate( false )
         , m_recordFrames( false )
+        , m_recordTimings( false )
+        , m_recordGraph( false )
         , m_isAboutToQuit( false )
     {
         // Set application and organization names in order to ensure uniform
@@ -319,6 +321,8 @@ namespace Ra
         // 3. Run the engine task queue.
         m_engine->getTasks( m_taskQueue.get(), dt );
 
+        if (m_recordGraph) {m_taskQueue->printTaskGraph(std::cout);}
+
         // Run one frame of tasks
         m_taskQueue->startTasks();
         m_taskQueue->waitForTasks();
@@ -342,6 +346,8 @@ namespace Ra
         // 6. Frame end.
         timerData.frameEnd = Core::Timer::Clock::now();
         timerData.numFrame = m_frameCounter;
+
+        if (m_recordTimings) { timerData.print(std::cout); }
 
         m_timerData.push_back( timerData );
 
@@ -491,5 +497,15 @@ namespace Ra
         }
 
         return res;
+    }
+
+    void BaseApplication::setRecordTimings(bool on)
+    {
+        m_recordTimings = on;
+    }
+
+    void BaseApplication::setRecordGraph(bool on)
+    {
+        m_recordGraph = on;
     }
 }

--- a/Applications/MainApplication/MainApplication.cpp
+++ b/Applications/MainApplication/MainApplication.cpp
@@ -222,31 +222,7 @@ namespace Ra
         bool res = m_engine->loadFile( pathStr );
         CORE_UNUSED( res );
         m_viewer->handleFileLoading( pathStr );
-
-        // Compute new scene aabb
-        Core::Aabb aabb;
-
-        std::vector<std::shared_ptr<Engine::RenderObject>> ros;
-        m_engine->getRenderObjectManager()->getRenderObjects( ros );
-
-        for ( auto ro : ros )
-        {
-            auto mesh = ro->getMesh();
-            auto pos = mesh->getGeometry().m_vertices;
-
-            for ( auto& p : pos )
-            {
-                p = ro->getLocalTransform() * p;
-            }
-
-            Ra::Core::Vector3 bmin = pos.getMap().rowwise().minCoeff().head<3>();
-            Ra::Core::Vector3 bmax = pos.getMap().rowwise().maxCoeff().head<3>();
-
-            aabb.extend( bmin );
-            aabb.extend( bmax );
-        }
-
-        m_viewer->fitCameraToScene( aabb );
+        m_mainWindow->fitCamera();
 
         emit loadComplete();
     }

--- a/Applications/MainApplication/MainApplication.cpp
+++ b/Applications/MainApplication/MainApplication.cpp
@@ -87,6 +87,19 @@ namespace Ra
         if (parser.isSet(numFramesOpt)) m_numFrames = parser.value(numFramesOpt).toUInt();
         if (parser.isSet(maxThreadsOpt)) m_maxThreads = parser.value(maxThreadsOpt).toUInt();
 
+
+        std::time_t startTime = std::time(nullptr);
+        std::tm* startTm = std::localtime(&startTime);
+        Ra::Core::StringUtils::stringPrintf(m_exportFoldername, "%4u%02u%02u-%02u%02u",
+                                            1900 + startTm->tm_year,
+                                            startTm->tm_mon,
+                                            startTm->tm_mday,
+                                            startTm->tm_hour,
+                                            startTm->tm_min);
+
+
+        QDir().mkdir(m_exportFoldername.c_str());
+
         // Boilerplate print.
         LOG( logINFO ) << "*** Radium Engine Main App  ***";
         std::stringstream config;
@@ -366,7 +379,7 @@ namespace Ra
     void BaseApplication::recordFrame()
     {
         std::string filename;
-        Ra::Core::StringUtils::stringPrintf(filename, "radiumframe_%06u.png", m_frameCounter);
+        Ra::Core::StringUtils::stringPrintf(filename, "%s/radiumframe_%06u.png", m_exportFoldername.c_str(), m_frameCounter);
         m_viewer->grabFrame(filename);
     }
 
@@ -376,6 +389,8 @@ namespace Ra
         emit stopping();
         m_mainWindow->cleanup();
         m_engine->cleanup();
+        // This will remove the directory if empty.
+        QDir().rmdir( m_exportFoldername.c_str());
     }
 
     bool BaseApplication::loadPlugins( const std::string& pluginsPath, const QStringList& loadList, const QStringList& ignoreList )

--- a/Applications/MainApplication/MainApplication.hpp
+++ b/Applications/MainApplication/MainApplication.hpp
@@ -136,6 +136,8 @@ namespace Ra
         bool m_realFrameRate;
 
         // Options to control monitoring and outputs
+        /// Name of the folder where exported data goes
+        std::string m_exportFoldername;
 
         /// If true, dump each frame to a PNG file.
         bool m_recordFrames;

--- a/Applications/MainApplication/MainApplication.hpp
+++ b/Applications/MainApplication/MainApplication.hpp
@@ -127,6 +127,7 @@ namespace Ra
         uint m_frameCounter;
         uint m_frameCountBeforeUpdate;
         uint m_numFrames;
+        uint m_maxThreads;
         std::vector<FrameTimerData> m_timerData;
 
         /// If true, use the wall clock to advance the engine. If false, use a fixed time step.

--- a/Applications/MainApplication/MainApplication.hpp
+++ b/Applications/MainApplication/MainApplication.hpp
@@ -82,6 +82,8 @@ namespace Ra
         void appNeedsToQuit();
         void setRealFrameRate( bool on );
         void setRecordFrames( bool on );
+        void setRecordTimings( bool on );
+        void setRecordGraph( bool on );
 
         void recordFrame();
 
@@ -133,8 +135,14 @@ namespace Ra
         /// If true, use the wall clock to advance the engine. If false, use a fixed time step.
         bool m_realFrameRate;
 
-        /// If true, dump each frame to a file.
+        // Options to control monitoring and outputs
+
+        /// If true, dump each frame to a PNG file.
         bool m_recordFrames;
+        /// If true, print the detailed timings of each frame
+        bool m_recordTimings;
+        /// If true, print the task graph;
+        bool m_recordGraph;
 
         bool m_isAboutToQuit;
     };

--- a/Applications/OpenGLExperiment/CMakeLists.txt
+++ b/Applications/OpenGLExperiment/CMakeLists.txt
@@ -54,5 +54,5 @@ target_link_libraries( ${app_target} # target
     ${Qt5_LIBRARIES}                # the Qt beast
 )
 if (MSVC)
-	set_property( TARGET ${app_target} PROPERTY IMPORTED_LOCATION "${RADIUM_SUBMODULES_INSTALL_DIRECTORY}/bin" )
+    set_property( TARGET ${app_target} PROPERTY IMPORTED_LOCATION "${RADIUM_SUBMODULES_INSTALL_DIRECTORY}/bin" )
 endif(MSVC)

--- a/Plugins/Animation/src/AnimationComponent.cpp
+++ b/Plugins/Animation/src/AnimationComponent.cpp
@@ -24,6 +24,7 @@ using Ra::Engine::ComponentMessenger;
 using Ra::Core::Animation::RefPose;
 using Ra::Core::Animation::Skeleton;
 using Ra::Core::Animation::WeightMatrix;
+using Ra::Core::Animation::Animation;
 
 namespace AnimationPlugin
 {
@@ -64,7 +65,7 @@ namespace AnimationPlugin
         }
 
         // get the current pose from the animation
-        if ( dt > 0 && m_animations.size() > 0)
+        if ( dt > 0 && !m_animations.empty() )
         {
             Ra::Core::Animation::Pose currentPose = m_animations[m_animationID].getPose(m_animationTime);
 
@@ -289,6 +290,13 @@ namespace AnimationPlugin
 
         ComponentMessenger::CallbackTypes<bool>::Getter resetOut = std::bind( &AnimationComponent::getWasReset, this );
         ComponentMessenger::getInstance()->registerOutput<bool>( getEntity(), this, id, resetOut);
+
+        ComponentMessenger::CallbackTypes<Animation>::Getter animOut = std::bind( &AnimationComponent::getAnimation, this );
+        ComponentMessenger::getInstance()->registerOutput<Animation>(getEntity(), this, id, animOut);
+
+        ComponentMessenger::CallbackTypes<Scalar>::Getter timeOut = std::bind( &AnimationComponent::getTime, this );
+        ComponentMessenger::getInstance()->registerOutput<Scalar>(getEntity(), this, id, timeOut);
+
     }
 
     const Ra::Core::Animation::Skeleton* AnimationComponent::getSkeletonOutput() const
@@ -387,5 +395,19 @@ namespace AnimationPlugin
         return found == m_boneDrawables.end() ?
                uint(-1) :
                (*found)->getBoneIndex();
+    }
+
+    const Ra::Core::Animation::Animation* AnimationComponent::getAnimation() const
+    {
+        if (m_animations.empty())
+        {
+            return nullptr;
+        }
+        return &m_animations[m_animationID];
+    }
+
+    const Scalar* AnimationComponent::getTime() const
+    {
+        return &m_animationTime;
     }
 }

--- a/Plugins/Animation/src/AnimationComponent.cpp
+++ b/Plugins/Animation/src/AnimationComponent.cpp
@@ -181,7 +181,7 @@ namespace AnimationPlugin
                 for( uint j = 0; j < handleAnim.size(); ++j ) {
                     if( m_skel.getLabel( i ) == handleAnim[j].m_name ) {
                         table[j] = i;
-                        auto set = handleAnim[j].m_anim.timeSchedule();
+                        auto set = std::move( handleAnim[j].m_anim.timeSchedule() );
                         keyTime.insert( set.begin(), set.end() );
                     }
                 }

--- a/Plugins/Animation/src/AnimationComponent.cpp
+++ b/Plugins/Animation/src/AnimationComponent.cpp
@@ -83,8 +83,11 @@ namespace AnimationPlugin
     {
 
         for( uint i = 0; i < m_skel.size(); ++i ) {
-            if( !m_skel.m_graph.isLeaf( i ) ) {
-                SkeletonBoneRenderObject* boneRenderObject = new SkeletonBoneRenderObject( m_skel.getLabel( i ), this, i, getRoMgr());
+            if( !m_skel.m_graph.isLeaf( i ) )
+            {
+                std::string name = m_skel.getLabel(i);
+                Ra::Core::StringUtils::appendPrintf( name, " (%d)", i);
+                SkeletonBoneRenderObject* boneRenderObject = new SkeletonBoneRenderObject( name, this, i, getRoMgr());
                 m_boneDrawables.push_back(boneRenderObject);
                 m_renderObjects.push_back( boneRenderObject->getRenderObjectIndex());
             } else {
@@ -375,5 +378,14 @@ namespace AnimationPlugin
         const Ra::Core::Transform& TBoneLocal = m_skel.getTransform(boneIdx, Ra::Core::Animation::Handle::SpaceType::LOCAL);
         auto diff = TBoneModel.inverse() *  transform;
         m_skel.setTransform(boneIdx,TBoneLocal * diff,  Ra::Core::Animation::Handle::SpaceType::LOCAL);
+    }
+
+    uint AnimationComponent::getBoneIdx(Ra::Core::Index index) const
+    {
+        auto found = std::find_if(m_boneDrawables.begin(), m_boneDrawables.end(),
+                                  [index](const auto& draw) { return draw->getRenderObjectIndex() == index; });
+        return found == m_boneDrawables.end() ?
+               uint(-1) :
+               (*found)->getBoneIndex();
     }
 }

--- a/Plugins/Animation/src/AnimationComponent.cpp
+++ b/Plugins/Animation/src/AnimationComponent.cpp
@@ -294,7 +294,7 @@ namespace AnimationPlugin
         ComponentMessenger::CallbackTypes<Animation>::Getter animOut = std::bind( &AnimationComponent::getAnimation, this );
         ComponentMessenger::getInstance()->registerOutput<Animation>(getEntity(), this, id, animOut);
 
-        ComponentMessenger::CallbackTypes<Scalar>::Getter timeOut = std::bind( &AnimationComponent::getTime, this );
+        ComponentMessenger::CallbackTypes<Scalar>::Getter timeOut = std::bind(&AnimationComponent::getTimeOutput, this );
         ComponentMessenger::getInstance()->registerOutput<Scalar>(getEntity(), this, id, timeOut);
 
     }
@@ -406,8 +406,13 @@ namespace AnimationPlugin
         return &m_animations[m_animationID];
     }
 
-    const Scalar* AnimationComponent::getTime() const
+    const Scalar* AnimationComponent::getTimeOutput() const
     {
         return &m_animationTime;
+    }
+
+    Scalar AnimationComponent::getTime() const
+    {
+        return m_animationTime;
     }
 }

--- a/Plugins/Animation/src/AnimationComponent.hpp
+++ b/Plugins/Animation/src/AnimationComponent.hpp
@@ -55,6 +55,8 @@ namespace AnimationPlugin
         void setAnimation( const uint i );
 
         uint getBoneIdx(Ra::Core::Index index) const ;
+        Scalar getTime() const;
+
 
         void handleSkeletonLoading( const Ra::Asset::HandleData* data, const std::map< uint, uint >& duplicateTable );
         void handleAnimationLoading( const std::vector< Ra::Asset::AnimationData* > data );
@@ -103,7 +105,7 @@ namespace AnimationPlugin
         const Ra::Core::Animation::WeightMatrix* getWeightsOutput() const;
         const bool*                              getWasReset() const;
         const Ra::Core::Animation::Animation* getAnimation() const;
-        const Scalar* getTime() const;
+        const Scalar* getTimeOutput() const;
 
     private:
         std::string m_contentName;

--- a/Plugins/Animation/src/AnimationComponent.hpp
+++ b/Plugins/Animation/src/AnimationComponent.hpp
@@ -102,6 +102,8 @@ namespace AnimationPlugin
         const Ra::Core::Animation::RefPose*      getRefPoseOutput() const;
         const Ra::Core::Animation::WeightMatrix* getWeightsOutput() const;
         const bool*                              getWasReset() const;
+        const Ra::Core::Animation::Animation* getAnimation() const;
+        const Scalar* getTime() const;
 
     private:
         std::string m_contentName;
@@ -112,7 +114,6 @@ namespace AnimationPlugin
         Ra::Core::Animation::WeightMatrix m_weights; // Skinning weights ( should go in skinning )
 
         std::vector<SkeletonBoneRenderObject*> m_boneDrawables ; // Vector of bone display objects
-        bool   m_showSkeleton;
         uint   m_animationID;
         bool   m_animationTimeStep;
         Scalar m_animationTime;

--- a/Plugins/Animation/src/AnimationComponent.hpp
+++ b/Plugins/Animation/src/AnimationComponent.hpp
@@ -54,6 +54,7 @@ namespace AnimationPlugin
         void toggleSlowMotion( const bool status );
         void setAnimation( const uint i );
 
+        uint getBoneIdx(Ra::Core::Index index) const ;
 
         void handleSkeletonLoading( const Ra::Asset::HandleData* data, const std::map< uint, uint >& duplicateTable );
         void handleAnimationLoading( const std::vector< Ra::Asset::AnimationData* > data );
@@ -67,6 +68,7 @@ namespace AnimationPlugin
         virtual Ra::Core::Transform getTransform(Ra::Core::Index roIdx) const override;
 
         virtual void setTransform(Ra::Core::Index roIdx, const Ra::Core::Transform& transform) override;
+
 
     private:
         // debug function to display the hierarchy

--- a/Plugins/Animation/src/AnimationPlugin.cpp
+++ b/Plugins/Animation/src/AnimationPlugin.cpp
@@ -5,6 +5,8 @@
 #include <QToolBar>
 
 #include <Engine/RadiumEngine.hpp>
+#include <Engine/Managers/SignalManager/SignalManager.hpp>
+#include <GuiBase/SelectionManager/SelectionManager.hpp>
 #include <AnimationSystem.hpp>
 
 #include <UI/AnimationUI.h>
@@ -36,6 +38,10 @@ namespace AnimationPlugin
     {
         m_system = new AnimationSystem;
         context.m_engine->registerSystem( "AnimationSystem", m_system );
+        context.m_engine->getSignalManager()->m_frameEndCallbacks.push_back(
+                std::bind(&AnimationPluginC::updateAnimTime, this)
+        );
+        m_selectionManager = context.m_selectionManager;
     }
 
     bool AnimationPluginC::doAddWidget( QString &name )
@@ -131,5 +137,10 @@ namespace AnimationPlugin
 
     void AnimationPluginC::toggleSlowMotion( bool status ) {
         m_system->toggleSlowMotion( status );
+    }
+
+    void AnimationPluginC::updateAnimTime()
+    {
+        m_widget->updateTime( m_system->getTime( m_selectionManager->currentItem()));
     }
 }

--- a/Plugins/Animation/src/AnimationPlugin.hpp
+++ b/Plugins/Animation/src/AnimationPlugin.hpp
@@ -43,6 +43,7 @@ namespace AnimationPlugin
         virtual bool doAddAction( int& nb ) override;
         virtual QAction* getAction( int id ) override;
 
+
     public slots:
         void toggleXray( bool on );
         void toggleSkeleton( bool on );
@@ -54,11 +55,13 @@ namespace AnimationPlugin
         void toggleAnimationTimeStep( bool status );
         void setAnimationSpeed( Scalar value );
         void toggleSlowMotion( bool status );
+        void updateAnimTime();
 
     private:
         class AnimationSystem* m_system;
         AnimationUI* m_widget;
 
+        Ra::GuiBase::SelectionManager* m_selectionManager;
     };
 
 } // namespace

--- a/Plugins/Animation/src/AnimationSystem.cpp
+++ b/Plugins/Animation/src/AnimationSystem.cpp
@@ -136,4 +136,34 @@ namespace AnimationPlugin
             registerComponent( entity, component );
         }
     }
+
+    Scalar AnimationSystem::getTime(const Ra::Engine::ItemEntry& entry) const
+    {
+        if (entry.isValid())
+        {
+            // If entry is an existing animation component, we return this one's time
+            // if not, look for other components in this entity to see if some are animation
+            std::vector<const AnimationComponent*> comps;
+            for (const auto& ec : m_components)
+            {
+                if (ec.first == entry.m_entity)
+                {
+                    const AnimationComponent* c = static_cast< AnimationComponent*>(ec.second);
+                    // Entry match, return that one
+                    if (ec.second == c)
+                    {
+                        return c->getTime();
+                    }
+                    comps.push_back(c);
+                }
+            }
+            // If comps is not empty, it means that we have a component in current entity
+            // We just pick the first one
+            if (!comps.empty())
+            {
+                return comps[0]->getTime();
+            }
+        }
+        return 0.f;
+    }
 }

--- a/Plugins/Animation/src/AnimationSystem.hpp
+++ b/Plugins/Animation/src/AnimationSystem.hpp
@@ -4,6 +4,7 @@
 #include <Engine/System/System.hpp>
 
 #include <AnimationPluginMacros.hpp>
+#include <Engine/ItemModel/ItemEntry.hpp>
 
 namespace AnimationPlugin
 {
@@ -40,6 +41,8 @@ namespace AnimationPlugin
         void toggleAnimationTimeStep( const bool status );
         void setAnimationSpeed( const Scalar value );
         void toggleSlowMotion( const bool status );
+
+        Scalar getTime(const Ra::Engine::ItemEntry& entry) const;
 
     private:
         bool m_isPlaying; /// See if animation is playing or paused

--- a/Plugins/Animation/src/UI/AnimationUI.cpp
+++ b/Plugins/Animation/src/UI/AnimationUI.cpp
@@ -92,3 +92,9 @@ void AnimationUI::on_m_slowMo_toggled( bool checked ) {
     emit toggleSlowMotion( checked );
 }
 
+void AnimationUI::updateTime(float t)
+{
+    QString text = QString("%1").arg(t);
+    ui->m_animationTimeDisplay->setText(text);
+}
+

--- a/Plugins/Animation/src/UI/AnimationUI.h
+++ b/Plugins/Animation/src/UI/AnimationUI.h
@@ -52,6 +52,8 @@ private slots:
 
 private:
     Ui::AnimationUI *ui;
+
+    void updateTime( float t);
 };
 
 #endif // ANIMATIONUI_H

--- a/Plugins/Animation/src/UI/AnimationUI.ui
+++ b/Plugins/Animation/src/UI/AnimationUI.ui
@@ -360,6 +360,20 @@ border-image: url(:/Assets/Images/stop_on.png);
             </property>
            </widget>
           </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="m_animTime">
+            <property name="text">
+             <string>Animation time </string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QLabel" name="m_animationTimeDisplay">
+            <property name="text">
+             <string>#a</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>

--- a/Plugins/Skinning/src/SkinningComponent.cpp
+++ b/Plugins/Skinning/src/SkinningComponent.cpp
@@ -45,6 +45,7 @@ void SkinningComponent::setupSkinning()
         m_refData.m_weights         = ComponentMessenger::getInstance()->get<WeightMatrix> ( getEntity(), m_contentsName );
 
         m_frameData.m_previousPose = m_refData.m_refPose;
+        m_frameData.m_frameCounter = 0;
         m_frameData.m_doSkinning = false;
         m_frameData.m_doReset = false;
 
@@ -76,6 +77,7 @@ void SkinningComponent::skin()
     if (reset && !m_frameData.m_doReset )
     {
         m_frameData.m_doReset = true;
+        m_frameData.m_frameCounter = 0;
     }
     else
     {
@@ -83,6 +85,7 @@ void SkinningComponent::skin()
         if ( !Ra::Core::Animation::areEqual( m_frameData.m_currentPose, m_frameData.m_previousPose))
         {
             m_frameData.m_doSkinning = true;
+            m_frameData.m_frameCounter++;
             m_frameData.m_refToCurrentRelPose = Ra::Core::Animation::relativePose(m_frameData.m_currentPose, m_refData.m_refPose);
             m_frameData.m_prevToCurrentRelPose = Ra::Core::Animation::relativePose(m_frameData.m_currentPose, m_frameData.m_previousPose);
 

--- a/Plugins/Skinning/src/SkinningPlugin.cpp
+++ b/Plugins/Skinning/src/SkinningPlugin.cpp
@@ -104,9 +104,9 @@ namespace SkinningPlugin
             << "Linear Blend Skinning" << "Dual Quaternion Skinning" << "Center of Rotation skinning" );
         m_skinningSelect->setEnabled( false );
 
-        m_actionLBS = new QAction(QIcon(":/Assets/Images/LB.png"), QString("Linear Blending"));
-        m_actionDQ  = new QAction(QIcon(":/Assets/Images/DQ_on.png"), QString("Dual Quaternion"));
-        m_actionCoR = new QAction(QIcon(":/Assets/Images/CoR.png"), QString("Center of Rotation"));
+        m_actionLBS = new QAction(QIcon(":/Assets/Images/LB.png"), QString("Linear Blending"),nullptr);
+        m_actionDQ  = new QAction(QIcon(":/Assets/Images/DQ_on.png"), QString("Dual Quaternion"), nullptr);
+        m_actionCoR = new QAction(QIcon(":/Assets/Images/CoR.png"), QString("Center of Rotation"),nullptr);
         m_actionLBS->setEnabled( false );
         m_actionDQ->setEnabled( false );
         m_actionCoR->setEnabled( false );

--- a/Shaders/BlinnPhong.frag.glsl
+++ b/Shaders/BlinnPhong.frag.glsl
@@ -26,7 +26,7 @@ float InShadow()
     float result = current > closest ? 1.0 : 0.0;
     return result;
 }
-#endif 
+#endif
 
 void main()
 {

--- a/cmake/CompileFlags.cmake
+++ b/cmake/CompileFlags.cmake
@@ -102,6 +102,10 @@ endif()
 
 # Additional flags depending on build options =================================
 
+if ("${CMAKE_BUILD_TYPE}"  STREQUAL "Release" )
+    add_definitions(-DNO_DEBUG_INFO)
+endif()
+
 if (${RADIUM_WITH_DOUBLE_PRECISION})
   add_definitions(-DCORE_USE_DOUBLE)
   message(STATUS "${PROJECT_NAME} : Using double precision.")

--- a/cmake/CompileFlags.cmake
+++ b/cmake/CompileFlags.cmake
@@ -89,7 +89,7 @@ elseif (MSVC)
         set (OMP_FLAG "")
     endif()
 
-    set(CMAKE_CXX_FLAGS                "/arch:AVX2 /GR- /EHs-c- /MP ${OMP_FLAG} ${CMAKE_CXX_FLAGS}")
+    set(CMAKE_CXX_FLAGS                "/arch:AVX2 /EHs-c- /MP ${OMP_FLAG} ${CMAKE_CXX_FLAGS}")
     set(CMAKE_CXX_FLAGS_DEBUG          "/D_DEBUG /DCORE_DEBUG /Od /Zi ${CMAKE_CXX_FLAGS_DEBUG} /MDd")
     set(CMAKE_CXX_FLAGS_RELEASE        "/DNDEBUG /Ox /fp:fast ${CMAKE_CXX_FLAGS_RELEASE} /MT")
     set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "/Zi ${CMAKE_CXX_FLAGS_RELEASE}")

--- a/src/Core/Animation/Animation.cpp
+++ b/src/Core/Animation/Animation.cpp
@@ -39,22 +39,24 @@ void Animation::normalize()
 {
     if (m_keys.size() == 0)
         return;
-    
+
     // sort the keys according to their timestamp
     sort(m_keys.begin(), m_keys.end(), KeyPoseComparator());
-    
+
+}
+Scalar Animation::getTime( Scalar timestamp ) const
+{
+    Scalar duration = m_keys.back().first;
+    // ping pong: d - abs(mod(x, 2 * d) - d)
+    return duration - std::abs(std::fmod(timestamp, 2 * duration) - duration);
 }
 
 Pose Animation::getPose(Scalar timestamp) const
 {
-    Scalar duration = m_keys.back().first;
-    
-    // ping pong: d - abs(mod(x, 2 * d) - d)
-    Scalar modifiedTime = duration - std::abs(fmod(timestamp, 2 * duration) - duration);
- 
+    Scalar modifiedTime = getTime(timestamp);
     if (modifiedTime <= m_keys.front().first)
         return m_keys.front().second;
-    
+
     for ( uint i = 0; i < m_keys.size() - 1; i++ )
     {
         if (modifiedTime >= m_keys[i].first && modifiedTime <= m_keys[i + 1].first)
@@ -65,7 +67,7 @@ Pose Animation::getPose(Scalar timestamp) const
             return Ra::Core::Animation::interpolatePoses(m_keys[i].second, m_keys[i + 1].second, t);
         }
     }
-    
+
     return m_keys.back().second;
 }
 

--- a/src/Core/Animation/Animation.cpp
+++ b/src/Core/Animation/Animation.cpp
@@ -46,6 +46,10 @@ void Animation::normalize()
 }
 Scalar Animation::getTime( Scalar timestamp ) const
 {
+    if (m_keys.empty())
+    {
+        return 0;
+    }
     Scalar duration = m_keys.back().first;
     // ping pong: d - abs(mod(x, 2 * d) - d)
     return duration - std::abs(std::fmod(timestamp, 2 * duration) - duration);

--- a/src/Core/Animation/Animation.hpp
+++ b/src/Core/Animation/Animation.hpp
@@ -11,7 +11,7 @@ namespace Animation {
 
 typedef std::pair<Scalar, Pose> KeyPose;
 
-class RA_CORE_API Animation 
+class RA_CORE_API Animation
 {
 public:
     // Add the key pose after the previous ones.
@@ -19,19 +19,23 @@ public:
     // timestamp must be given in seconds.
     void addKeyPose(const Pose& pose, Scalar timestamp);
     void addKeyPose(const KeyPose& keyPose);
-    
+
     // Remove all the key poses.
     void clear();
-    
+
     bool isEmpty() const;
-    
+
     // Re-order the poses by chronological order.
     void normalize();
-    
+
     // Get the pose corresponding to the given timestamp.
     // timestamp must be given in seconds.
     Pose getPose(Scalar timestamp) const;
-    
+
+    // Get the internal animation time from a timestamp.
+    // Guaranteed to be between 0 and the animation last time
+    Scalar getTime(Scalar timestamp) const;
+
 private:
     std::vector<KeyPose> m_keys;
 };

--- a/src/Core/Animation/Skinning/SkinningData.hpp
+++ b/src/Core/Animation/Skinning/SkinningData.hpp
@@ -57,6 +57,9 @@ namespace Skinning
         /// Current vertex normals
         Ra::Core::Vector3Array m_currentNormal;
 
+        /// Number of animation frames
+        uint m_frameCounter;
+
         /// Indicator whether skinning must be processed.
         /// It is set to true if the current pose is different from previous.
         bool m_doSkinning;

--- a/src/Core/CoreMacros.hpp
+++ b/src/Core/CoreMacros.hpp
@@ -74,10 +74,11 @@
 // ----------------------------------------------------------------------------
 
 // This tells apart between debug and release builds :
-// CORE_DEBUG is defined in debug builds and CORE_RELEASe in release builds.
+// DEBUG is defined in debug builds and RELEASE in release builds.
+// Additionally REL_DEB is defined on release build with debug info
 // Also the macro ON_DEBUG() can be used to execute an expression only on debug.
 // By default, debug has assert macros enabled. In release builds
-// asserts are disabled except if explicitly required by 
+// asserts are disabled except if explicitly required by
 // defining CORE_USE_ASSERT
 
 
@@ -99,6 +100,10 @@
 #else // --------------------------------------------------------------- Release
 
 #   define RELEASE
+
+#ifndef NO_DEBUG_INFO
+#   define REL_DEB
+#endif
 
 #   undef CORE_DEBUG
 #   undef DEBUG
@@ -281,8 +286,9 @@ template<int x> struct size;
     std::stringstream stream;           \
     stream << DESC;                     \
     fprintf(stderr,                     \
-          FMT,__FILE__,__LINE__, #EXP, stream.str().c_str() );   \
-MACRO_END
+          FMT,__FILE__,__LINE__,        \
+          #EXP, stream.str().c_str() ); \
+    MACRO_END
 
 
 

--- a/src/Core/Geometry/Approximation/VariationalShapeApproximation.hpp
+++ b/src/Core/Geometry/Approximation/VariationalShapeApproximation.hpp
@@ -17,7 +17,8 @@ namespace Geometry {
  */
 enum class MetricType {
     L2,
-    L21
+    L21,
+    LLOYD
 };
 
 
@@ -290,6 +291,56 @@ protected:
 
 
 
+/**
+ * @brief This is a specialized version of the VSA for the L21 metric.
+ */
+template < uint K_Region >
+class VariationalShapeApproximation< K_Region, MetricType::LLOYD > : public VariationalShapeApproximationBase< K_Region > {
+public:
+    //////////////////////////////////////////////////////////////////////////////
+    // TYPEDEF
+    //////////////////////////////////////////////////////////////////////////////
+    //typedef typename VariationalShapeApproximationBase< K_Region >::Triangle Triangle;
+    typedef typename VariationalShapeApproximationBase< K_Region >::Proxy    Proxy;
+
+
+
+    //////////////////////////////////////////////////////////////////////////////
+    // CONSTRUCTOR
+    //////////////////////////////////////////////////////////////////////////////
+    using VariationalShapeApproximationBase< K_Region >::VariationalShapeApproximationBase;
+
+
+
+    //////////////////////////////////////////////////////////////////////////////
+    // DESTRUCTOR
+    //////////////////////////////////////////////////////////////////////////////
+    virtual ~VariationalShapeApproximation();
+
+
+
+protected:
+    //////////////////////////////////////////////////////////////////////////////
+    // PROXY FITTING
+    //////////////////////////////////////////////////////////////////////////////
+    inline void proxy_fitting() override final;         ///< Computes the Proxy fitting for the L21 metric.
+
+
+
+    //////////////////////////////////////////////////////////////////////////////
+    // ENERGY
+    //////////////////////////////////////////////////////////////////////////////
+    inline Scalar E( const TriangleIdx& T, const Proxy& P ) const override final;      ///< Computes the energy function for the L21 metric.
+};
+
+
+
+//============================================================================
+//============================================================================
+//============================================================================
+
+
+
 //////////////////////////////////////////////////////////////////////////////
 // ALIAS
 //////////////////////////////////////////////////////////////////////////////
@@ -301,6 +352,9 @@ using VSA_L2 = VariationalShapeApproximation< K_Region, MetricType::L2 >;
 
 template < uint K_Region >
 using VSA_L21 = VariationalShapeApproximation< K_Region, MetricType::L21 >;
+
+template < uint K_Region >
+using VSA_L21 = VariationalShapeApproximation< K_Region, MetricType::LLOYD >;
 
 
 

--- a/src/Core/Math/ColorPresets.hpp
+++ b/src/Core/Math/ColorPresets.hpp
@@ -112,6 +112,20 @@ namespace Ra{
                 return (uint32_t(scaled[3])<<24) | (uint32_t(scaled[0])<<16) |(uint32_t(scaled[1])<<8) |(uint32_t(scaled[2])<<0);
             }
 
+            template <typename C = Color>
+            inline std::vector<C> scatter( const uint size, const Scalar gamma ) {
+                std::vector<C> color(size);
+                if( size > 1 )
+                for( uint i = 0; i < size; ++i ) {
+                    color[i] = fromHSV( (Scalar(i)/Scalar(size-1)) * 0.777 );
+                    color[i] = ( color[i] + C::Constant(gamma) ) * 0.5;
+                }
+                else {
+                    color[0] = Red();
+                }
+                std::random_shuffle( color.begin(), color.end() );
+                return color;
+            }
         }
     }
 }

--- a/src/Core/Math/LinearAlgebra.hpp
+++ b/src/Core/Math/LinearAlgebra.hpp
@@ -163,6 +163,11 @@ namespace Ra
             template<typename Vector_>
             inline Scalar angle( const Vector_& v1, const Vector_& v2 );
 
+            /// Get the spherical linear interpolation between two unit non-colinear vectors.
+            /// works for types where the cross-product is defined (i.e. 2D and 3D vectors).
+            template<typename Vector_>
+            inline Vector_ slerp( const Vector_& v1, const Vector_& v2, Scalar t );
+
             /// @return the projection of point on the plane define by plane and planeNormal
             inline Vector3 projectOnPlane(const Vector3& planePos, const Vector3& planeNormal, const Vector3& point);
 
@@ -184,6 +189,7 @@ namespace Ra
             /// If the vector's norm is 0, the vector remains null
             template< typename Vector_ >
             inline Scalar getNormAndNormalizeSafe(Vector_& v);
+
         }
 
         namespace MatrixUtils

--- a/src/Core/Math/LinearAlgebra.inl
+++ b/src/Core/Math/LinearAlgebra.inl
@@ -134,6 +134,15 @@ namespace Core
         return point + planeNormal * (planePos - point).dot(planeNormal);
     }
 
+    template <typename Vector_>
+    Vector_ Ra::Core::Vector::slerp(const Vector_& v1, const Vector_& v2, Scalar t)
+    {
+        const Scalar dot = v1.dot(v2);
+        const Scalar theta = t* angle(v1, v2);
+        const Vector_ relativeVec = (v2 - v1*dot).normalized();
+        return ((v1 *std::cos(theta)) + (relativeVec * std::sin(theta)));
+    }
+
     // Reference : Paolo Baerlocher, Inverse Kinematics techniques for interactive posture control
     // of articulated figures (PhD Thesis), p.138. EPFL, 2001.
     // http://www0.cs.ucl.ac.uk/research/equator/papers/Documents2002/Paolo%20Baerlocher_Thesis_2001.pdf

--- a/src/Core/Math/Math.hpp
+++ b/src/Core/Math/Math.hpp
@@ -72,6 +72,10 @@ namespace Ra
             template <typename T>
             inline constexpr T saturate( T v );
 
+            /// Returns the linear interpolation between a and b
+            template <typename T>
+            inline constexpr T lerp( const T& a, const T&b, Scalar t);
+
         } // namespace Math
     }
 }

--- a/src/Core/Math/Math.inl
+++ b/src/Core/Math/Math.inl
@@ -120,6 +120,11 @@ namespace Ra
                return std::abs(b-a) < eps;
             }
 
+            template <typename T>
+            constexpr T lerp(const T& a, const T& b, Scalar t)
+            {
+                return (1-t) * a + t * b;
+            }
         }
     }
 }

--- a/src/Core/Math/PolyLine.cpp
+++ b/src/Core/Math/PolyLine.cpp
@@ -99,6 +99,8 @@ Ra::Core::Vector3 PolyLine::f( Scalar t ) const
     return m_pts[i] + ((param - lprev) / (m_lengths[i] - lprev)) * m_ptsDiff[i];
 }
 
+
+
 }
 }
 

--- a/src/Core/Math/PolyLine.cpp
+++ b/src/Core/Math/PolyLine.cpp
@@ -62,21 +62,49 @@ Scalar PolyLine::project( const Vector3& p ) const
     CORE_ASSERT( m_pts.size() > 1, "Line must have at least two points" );
     Scalar sqDist = std::numeric_limits<Scalar>::max();
     uint segment = 0;
-    Scalar t = 0;
+    std::vector<Scalar> ts;
+    std::vector<Scalar> ds;
+    ts.reserve( m_ptsDiff.size());
+    ds.reserve( m_ptsDiff.size());
+
     for ( uint i = 0; i < m_ptsDiff.size(); ++i )
     {
         Scalar proj = DistanceQueries::projectOnSegment( p, m_pts[i], m_ptsDiff[i] );
         Scalar d = (p - (m_pts[i] + proj * (m_ptsDiff[i]))).squaredNorm();
+        ds.push_back(d);
+        ts.push_back( proj);
         if ( d < sqDist )
         {
-            sqDist = d;
-            t = proj;
+             sqDist = d;
             segment = i;
         }
     }
 
     CORE_ASSERT( segment < m_ptsDiff.size(), "Invalid index" );
-    return getLineParameter( segment, t );
+    Scalar t  = ts[segment];
+    if ( t > 0 && t < 1)
+    {
+        bool prev = segment > 0 && ts[segment - 1] > 0 && ts[segment - 1] < 1;
+        bool next = segment < m_ptsDiff.size() - 1 && ts[segment + 1] > 0 && ts[segment + 1] < 1;
+        if (prev || next)
+        {
+            if (prev && next)
+            {
+                prev = ds[segment - 1] < ds[segment + 1];
+            }
+            uint i = prev ? segment - 1 : segment;
+            Ra::Core::Vector3 ba = -m_ptsDiff[i];
+            Ra::Core::Vector3 bc = m_ptsDiff[i + 1];
+            Ra::Core::Vector3 bp = p - m_pts[i+1];
+            Scalar c1 = Ra::Core::Vector::cotan(ba, bp);
+            Scalar c2 = Ra::Core::Vector::cotan(bp, bc);
+
+            Scalar t1 = getLineParameter(i, ts[i]);
+            Scalar t2 = getLineParameter(i + 1, ts[i + 1]);
+            return (c1 * t1 + c2 * t2) / (c1 + c2);
+        }
+    }
+    return getLineParameter(segment, t);
 }
 
 Ra::Core::Vector3 PolyLine::f( Scalar t ) const
@@ -98,6 +126,26 @@ Ra::Core::Vector3 PolyLine::f( Scalar t ) const
     // Now we know point f(t) is between point Pi and Pi+1;
     return m_pts[i] + ((param - lprev) / (m_lengths[i] - lprev)) * m_ptsDiff[i];
 }
+
+    uint PolyLine::getNearestSegment(const Vector3& p) const
+    {
+        CORE_ASSERT( m_pts.size() > 1, "Line must have at least two points" );
+        Scalar sqDist = std::numeric_limits<Scalar>::max();
+        uint segment = 0;
+        for ( uint i = 0; i < m_ptsDiff.size(); ++i )
+        {
+            Scalar proj = DistanceQueries::projectOnSegment( p, m_pts[i], m_ptsDiff[i] );
+            Scalar d = (p - (m_pts[i] + proj * (m_ptsDiff[i]))).squaredNorm();
+            if ( d < sqDist )
+            {
+                sqDist = d;
+                segment = i;
+            }
+        }
+
+        CORE_ASSERT( segment < m_ptsDiff.size(), "Invalid index" );
+        return segment;
+    }
 
 
 

--- a/src/Core/Math/PolyLine.hpp
+++ b/src/Core/Math/PolyLine.hpp
@@ -47,13 +47,19 @@ namespace Ra
             /// ith segment closest from point p.
             Scalar projectOnSegment(const Vector3& p, uint segment) const;
 
+            /// Returns the index of the nearest segment.
+            uint getNearestSegment(const Vector3& p) const;
+
+            /// Returns the index of the segment to which t belons
+            inline uint getSegmentIndex(Scalar t) const;
+
             /// Returns the parameter t in [0,1] corresponding to the point on the line
             /// which is the closest point from p.
-            Scalar project( const Vector3& p )const;
+            Scalar project(const Vector3& p) const;
 
             /// Return a point on the line corresponding to parameter t in [0;1].
             /// Values of t below 0 map to the first point, and values above 1 to the last.
-            Vector3 f(Scalar t) const ;
+            Vector3 f(Scalar t) const;
 
         protected:
             /// Update the precomputed values after new points have been set.

--- a/src/Core/Math/PolyLine.hpp
+++ b/src/Core/Math/PolyLine.hpp
@@ -25,6 +25,9 @@ namespace Ra
             /// Get the ith segment AB as starting point A and vector AB.
             inline void getSegment(uint segment, Vector3& aOut, Vector3& abOut) const;
 
+            /// Get the segment vector ( Pi+1 - Pi)
+            inline const Vector3Array& getSegmentVectors() const;
+
             /// Get the aabb of the polyline.
             inline Aabb aabb() const;
 

--- a/src/Core/Math/PolyLine.inl
+++ b/src/Core/Math/PolyLine.inl
@@ -1,39 +1,55 @@
 #include "PolyLine.hpp"
 #include <Core/Geometry/PointCloud/PointCloud.hpp>
 
-namespace Ra {
-namespace Core {
+namespace Ra
+{
+    namespace Core
+    {
 
-const Vector3Array& PolyLine::getPoints() const
-{
-    return m_pts;
-}
+        const Vector3Array& PolyLine::getPoints() const
+        {
+            return m_pts;
+        }
 
-Scalar PolyLine::length() const
-{
-    return m_lengths.back();
-}
+        Scalar PolyLine::length() const
+        {
+            return m_lengths.back();
+        }
 
-Ra::Core::Aabb PolyLine::aabb() const
-{
-    return PointCloud::aabb( m_pts );
-}
+        Ra::Core::Aabb PolyLine::aabb() const
+        {
+            return PointCloud::aabb(m_pts);
+        }
 
-Scalar PolyLine::getLineParameter ( uint segment, Scalar tSegment ) const
-{
-    CORE_ASSERT( segment < m_ptsDiff.size(), "invalid segment index");
-    const Scalar lprev = segment  > 0 ? m_lengths[segment - 1] : 0;
-    const Scalar lSegment = m_lengths[segment] - lprev;
-    return ((lSegment * tSegment) + lprev) / length();
-}
+        Scalar PolyLine::getLineParameter(uint segment, Scalar tSegment) const
+        {
+            CORE_ASSERT(segment < m_ptsDiff.size(), "invalid segment index");
+            const Scalar lprev = segment > 0 ? m_lengths[segment - 1] : 0;
+            const Scalar lSegment = m_lengths[segment] - lprev;
+            return ((lSegment * tSegment) + lprev) / length();
+        }
 
-void PolyLine::getSegment(uint segment, Vector3& aOut, Vector3& abOut) const
-{
-    CORE_ASSERT( segment < m_ptsDiff.size(), "Invalid segment index.");
-    aOut = m_pts[segment]; abOut = m_ptsDiff[segment];
+        void PolyLine::getSegment(uint segment, Vector3& aOut, Vector3& abOut) const
+        {
+            CORE_ASSERT(segment < m_ptsDiff.size(), "Invalid segment index.");
+            aOut = m_pts[segment];
+            abOut = m_ptsDiff[segment];
+        }
+
+        const Vector3Array& PolyLine::getSegmentVectors() const
+        {
+            return m_ptsDiff;
+        }
+
+        uint PolyLine::getSegmentIndex(Scalar t) const
+        {
+            // This could be optimized by dichotomy
+            Scalar param = length() * Ra::Core::Math::saturate(t);
+            uint i = 0;
+            while (m_lengths[i] < param)
+            { ++i; }
+            return i;
+        }
+
+    }
 }
-const Vector3Array& PolyLine::getSegmentVectors() const
-{
-    return m_ptsDiff;
-}
-}}

--- a/src/Core/Math/PolyLine.inl
+++ b/src/Core/Math/PolyLine.inl
@@ -32,4 +32,8 @@ void PolyLine::getSegment(uint segment, Vector3& aOut, Vector3& abOut) const
     CORE_ASSERT( segment < m_ptsDiff.size(), "Invalid segment index.");
     aOut = m_pts[segment]; abOut = m_ptsDiff[segment];
 }
+const Vector3Array& PolyLine::getSegmentVectors() const
+{
+    return m_ptsDiff;
+}
 }}

--- a/src/Core/Mesh/HalfEdge.hpp
+++ b/src/Core/Mesh/HalfEdge.hpp
@@ -30,7 +30,7 @@ namespace Ra
         /// face and prev/next indices.
         /// Edges shared by more than 2 triangles are not supported and will cause an assert during
         /// the call to build().
-        class HalfEdgeData
+        class RA_CORE_API HalfEdgeData
         {
         public:
             /// Build the half edge data from a mesh.

--- a/src/Core/Mesh/MeshUtils.hpp
+++ b/src/Core/Mesh/MeshUtils.hpp
@@ -47,6 +47,11 @@ namespace Ra
 
             RA_CORE_API void removeDuplicates(TriangleMesh& mesh, std::vector<VertexIdx>& vertexMap);
 
+
+            /// Returns a list of edges from a given triangle mesh
+            RA_CORE_API inline std::vector<Ra::Core::Vector2ui> getEdges( const TriangleMesh& mesh );
+
+            /// Results of a raycast vs a mesh
             struct RayCastResult { int m_hitTriangle; int m_nearestVertex; Scalar m_t; };
 
             /// Return the index of the triangle hit by the ray or -1 if there's no hit.

--- a/src/Core/Tasks/TaskQueue.cpp
+++ b/src/Core/Tasks/TaskQueue.cpp
@@ -102,12 +102,12 @@ namespace Ra
            for ( const auto& pre : m_pendingDepsPre )
            {
                ON_ASSERT(bool result =) addDependency( pre.first, pre.second );
-               CORE_WARN_IF( !result, "Pending dependency unresolved : " << pre.second);
+               CORE_WARN_IF( !result, "Pending dependency unresolved : " << m_tasks[pre.first]->getName() <<" -> (" << pre.second<<")");
            }
            for ( const auto& pre : m_pendingDepsSucc )
            {
                ON_ASSERT(bool result =) addDependency( pre.first, pre.second );
-               CORE_WARN_IF( result, "Pending dependency unresolved : " << pre.first );
+               CORE_WARN_IF( !result, "Pending dependency unresolved : (" << pre.first  <<") -> "<< m_tasks[pre.second]->getName());
            }
            m_pendingDepsPre.clear();
            m_pendingDepsSucc.clear();

--- a/src/Core/Tasks/TaskQueue.cpp
+++ b/src/Core/Tasks/TaskQueue.cpp
@@ -240,6 +240,7 @@ namespace Ra
 
                 // Run task
                 m_timerData[task].start = Timer::Clock::now();
+                m_timerData[task].threadId = id;
                 m_tasks[task]->process();
                 m_timerData[task].end = Timer::Clock::now();
 

--- a/src/Core/Tasks/TaskQueue.cpp
+++ b/src/Core/Tasks/TaskQueue.cpp
@@ -102,12 +102,12 @@ namespace Ra
            for ( const auto& pre : m_pendingDepsPre )
            {
                ON_ASSERT(bool result =) addDependency( pre.first, pre.second );
-               CORE_ASSERT( result, "Pending dependency unresolved : " << pre.second);
+               CORE_WARN_IF( !result, "Pending dependency unresolved : " << pre.second);
            }
            for ( const auto& pre : m_pendingDepsSucc )
            {
                ON_ASSERT(bool result =) addDependency( pre.first, pre.second );
-               CORE_ASSERT( result, "Pending dependency unresolved : " << pre.first );
+               CORE_WARN_IF( result, "Pending dependency unresolved : " << pre.first );
            }
            m_pendingDepsPre.clear();
            m_pendingDepsSucc.clear();
@@ -269,7 +269,7 @@ namespace Ra
             } // End of while(true)
         }
 
-        void TaskQueue::printTraskGraph(std::ostream& output) const
+        void TaskQueue::printTaskGraph(std::ostream& output) const
         {
             output<<"digraph tasks {"<<std::endl;
 

--- a/src/Core/Tasks/TaskQueue.hpp
+++ b/src/Core/Tasks/TaskQueue.hpp
@@ -43,6 +43,7 @@ namespace Ra
             {
                 Timer::TimePoint start;
                 Timer::TimePoint end;
+                uint threadId;
                 std::string taskName;
             };
 

--- a/src/Core/Tasks/TaskQueue.hpp
+++ b/src/Core/Tasks/TaskQueue.hpp
@@ -96,7 +96,7 @@ namespace Ra
 
 
             /// Prints the current task graph in dot format
-            void printTraskGraph( std::ostream& output ) const;
+            void printTaskGraph( std::ostream& output ) const;
 
         private:
 

--- a/src/Engine/Assets/KeyFrame/KeyFrame.hpp
+++ b/src/Engine/Assets/KeyFrame/KeyFrame.hpp
@@ -93,10 +93,11 @@ public:
         return m_keyframe.empty();
     }
 
-    inline std::set< Time > timeSchedule() const {
-        std::set< Time > time;
+    inline std::vector< Time > timeSchedule() const {
+        std::vector< Time > time;
         for( const auto& it : m_keyframe ) {
-            time.insert( it.first );
+            const Time t = Scalar(it.first);
+            time.push_back( t );
         }
         return time;
     }
@@ -122,22 +123,37 @@ protected:
                            FRAME& F1,
                            Scalar& dt ) const {
         auto it = m_keyframe.find( t );
+        // exact match
         if( it != m_keyframe.end() ) {
             F0 = it->second;
             F1 = it->second;
             dt = 0.0;
             return;
         }
+        // before first
+        if (t < m_keyframe.begin()->first)
+        {
+            F0 = m_keyframe.begin()->second;
+            F1 = F0;
+            dt = 0.0;
+            return;
+        }
+        // after last
+        if (t > m_keyframe.rbegin()->first)
+        {
+            F0 = m_keyframe.rbegin()->second;
+            F1 = F0;
+            dt = 0.0;
+            return;
+        }
+        // in-between
         auto upper = m_keyframe.upper_bound( t );
         auto lower = upper;
         --lower;
-
         F0 = lower->second;
-        F1 = upper->second;
-
         Time t0 = lower->first;
+        F1 = upper->second;
         Time t1 = upper->first;
-
         dt = ( t - t0 ) / ( t1 - t0 );
     }
 

--- a/src/Engine/Entity/Entity.cpp
+++ b/src/Engine/Entity/Entity.cpp
@@ -23,7 +23,7 @@ namespace Ra
 
         Entity::~Entity()
         {
-            // Ensure components are deleted before the entity for conssistent
+            // Ensure components are deleted before the entity for consistent
             // ordering of signals.
             m_components.clear();
             RadiumEngine::getInstance()->getSignalManager()->fireEntityDestroyed( ItemEntry(this) );

--- a/src/Engine/Managers/SignalManager/SignalManager.cpp
+++ b/src/Engine/Managers/SignalManager/SignalManager.cpp
@@ -46,4 +46,9 @@ void SignalManager::callFunctions(const std::vector<Callback>& funcs, const Item
         for (const auto& f : funcs) { f(arg); }
     }
 }
+
+    void SignalManager::fireFrameEnded() const
+    {
+        for (const auto&f :m_frameEndCallbacks) { f(); }
+    }
 }}

--- a/src/Engine/Managers/SignalManager/SignalManager.hpp
+++ b/src/Engine/Managers/SignalManager/SignalManager.hpp
@@ -30,6 +30,7 @@ namespace Engine {
     public:
         // Callbacks are functions which accept an item entry.
         typedef std::function<void( const ItemEntry& )> Callback;
+        typedef std::function<void( void )> EoFCallback;
 
     public:
         SignalManager() : m_isOn( true ) {}
@@ -40,8 +41,10 @@ namespace Engine {
         void fireComponentAdded     (const ItemEntry& component ) const;
         void fireComponentRemoved   (const ItemEntry& component ) const;
 
-        void fireRenderObjectAdded  ( const ItemEntry& ro) const;
-        void fireRenderObjectRemoved(const ItemEntry& ro ) const;
+        void fireRenderObjectAdded  ( const ItemEntry& ro ) const;
+        void fireRenderObjectRemoved( const ItemEntry& ro ) const;
+
+        void fireFrameEnded() const;
 
         void setOn( bool on )  { m_isOn = on; }
 
@@ -59,6 +62,7 @@ namespace Engine {
         std::vector<Callback> m_componentRemovedCallbacks;
         std::vector<Callback> m_roAddedCallbacks;
         std::vector<Callback> m_roRemovedCallbacks;
+        std::vector<EoFCallback> m_frameEndCallbacks;
     };
 }}
 

--- a/src/Engine/RadiumEngine.cpp
+++ b/src/Engine/RadiumEngine.cpp
@@ -66,6 +66,7 @@ namespace Ra
         void RadiumEngine::endFrameSync()
         {
             m_entityManager->swapBuffers();
+            m_signalManager->fireFrameEnded();
         }
 
         void RadiumEngine::getTasks( Core::TaskQueue* taskQueue,  Scalar dt )

--- a/src/Engine/Renderer/RenderObject/RenderObjectManager.cpp
+++ b/src/Engine/Renderer/RenderObject/RenderObjectManager.cpp
@@ -43,9 +43,6 @@ namespace Ra
 
             m_renderObjectByType[(int)type].insert( index );
 
-            if (type == RenderObjectType::Fancy)
-                m_fancyBVH.insertLeaf(newRenderObject);
-
             Engine::RadiumEngine::getInstance()->getSignalManager()->fireRenderObjectAdded(
                     ItemEntry( renderObject->getComponent()->getEntity(),
                                renderObject->getComponent(),
@@ -60,7 +57,6 @@ namespace Ra
             // FIXME(Charly): Should we check if the render object is in the double buffer map ?
             std::shared_ptr<RenderObject> renderObject = m_renderObjects.at( index );
 
-
             Engine::RadiumEngine::getInstance()->getSignalManager()->fireRenderObjectRemoved(
                     ItemEntry( renderObject->getComponent()->getEntity(),
                                renderObject->getComponent(),
@@ -69,6 +65,7 @@ namespace Ra
             // Lock after signal has been fired (as this signal can cause another RO to be deleted)
             std::lock_guard<std::mutex> lock( m_doubleBufferMutex );
             m_renderObjects.remove( index );
+
             auto type = renderObject->getType();
             m_renderObjectByType[(int)type].erase( index );
             renderObject.reset();
@@ -99,19 +96,10 @@ namespace Ra
             // Take the mutex
             std::lock_guard<std::mutex> lock( m_doubleBufferMutex );
 
-            /*if (type == RenderObjectType::Fancy)
+            //// Copy each element in m_renderObjects
+            for ( const auto& idx : m_renderObjectByType[(int)type] )
             {
-                Core::Matrix4 mvp(renderData.projMatrix * renderData.viewMatrix);
-                m_fancyBVH.update();
-                m_fancyBVH.getInFrustumSlow(objectsOut, Core::Frustum(mvp));
-            }
-            else*/
-            {
-                //// Copy each element in m_renderObjects
-                for ( const auto& idx : m_renderObjectByType[(int)type] )
-                {
-                    objectsOut.push_back( m_renderObjects.at( idx ) );
-                }
+                objectsOut.push_back( m_renderObjects.at( idx ) );
             }
         }
 

--- a/src/Engine/Renderer/RenderObject/RenderObjectManager.cpp
+++ b/src/Engine/Renderer/RenderObject/RenderObjectManager.cpp
@@ -3,6 +3,7 @@
 
 #include <Engine/RadiumEngine.hpp>
 
+#include <Engine/Entity/Entity.hpp>
 #include <Engine/Component/Component.hpp>
 
 #include <Engine/Renderer/RenderObject/RenderObject.hpp>
@@ -154,6 +155,34 @@ namespace Ra
                 }
             }
             return result;
+        }
+
+        Core::Aabb RenderObjectManager::getSceneAabb() const
+        {
+            Core::Aabb aabb;
+
+
+            for ( auto ro: m_renderObjects)
+            {
+                if (ro->isVisible())
+                {
+                    Core::Transform t = ro->getComponent()->getEntity()->getTransform();
+                    auto mesh = ro->getMesh();
+                    auto pos = mesh->getGeometry().m_vertices;
+
+                    for (auto& p : pos)
+                    {
+                        p = t * ro->getLocalTransform() * p;
+                    }
+
+                    const Ra::Core::Vector3 bmin = pos.getMap().rowwise().minCoeff().head<3>();
+                    const Ra::Core::Vector3 bmax = pos.getMap().rowwise().maxCoeff().head<3>();
+
+                    aabb.extend(bmin);
+                    aabb.extend(bmax);
+                }
+            }
+            return aabb;
         }
     }
 } // namespace Ra

--- a/src/Engine/Renderer/RenderObject/RenderObjectManager.hpp
+++ b/src/Engine/Renderer/RenderObject/RenderObjectManager.hpp
@@ -50,8 +50,6 @@ namespace Ra
             /// Returns true if the index points to a valid render object.
             bool exists( const Core::Index& index) const;
 
-            bool isDirty() const;
-
             void renderObjectExpired( const Ra::Core::Index& idx );
 
             /// Return the total number of faces drawn
@@ -59,6 +57,9 @@ namespace Ra
 
             /// Return the total number of vertices drawn
             uint getNumVertices() const;
+
+            /// Return the AABB of all visible render objects
+            Core::Aabb getSceneAabb() const;
 
         private:
             Core::IndexMap<std::shared_ptr<RenderObject>> m_renderObjects;

--- a/src/Engine/Renderer/RenderObject/RenderObjectManager.hpp
+++ b/src/Engine/Renderer/RenderObject/RenderObjectManager.hpp
@@ -64,8 +64,6 @@ namespace Ra
         private:
             Core::IndexMap<std::shared_ptr<RenderObject>> m_renderObjects;
 
-            mutable Core::BVH<RenderObject> m_fancyBVH ;
-
             std::array<std::set<Core::Index>, (int)RenderObjectType::Count> m_renderObjectByType;
 
             mutable std::mutex m_doubleBufferMutex;

--- a/src/GuiBase/TimerData/FrameTimerData.cpp
+++ b/src/GuiBase/TimerData/FrameTimerData.cpp
@@ -2,115 +2,36 @@
 
 namespace Ra
 {
-
-#if 0
-    LoggableFrameTimerData::LoggableFrameTimerData( uint average )
-        : m_average( average )
+    void FrameTimerData::print(std::ostream& ostream) const
     {
-    }
 
-    void LoggableFrameTimerData::addFrame( const FrameTimerData& data )
-    {
-        m_frames.push_back( data );
-    }
+        long totalTime = Ra::Core::Timer::getIntervalMicro(frameStart, frameEnd);
 
-    void LoggableFrameTimerData::log( el::base::type::ostream_t& os ) const
-    {
-        if ( m_average == 1 )
+        ostream<<"frame "<< numFrame <<": "<<totalTime<<"\n";
+        ostream<<"{"<<"\n";
         {
-            printTimerData( os );
-        }
-        else
-        {
-            printAverageTimerData( os );
-        }
+            long evStart = Ra::Core::Timer::getIntervalMicro(frameStart, eventsStart);
+            long evEnd = Ra::Core::Timer::getIntervalMicro(frameStart, eventsEnd);
 
-        m_frames.clear();
-    }
+            long taStart = Ra::Core::Timer::getIntervalMicro(frameStart, tasksStart);
+            long taEnd = Ra::Core::Timer::getIntervalMicro(frameStart, tasksEnd);
 
-    void LoggableFrameTimerData::printTimerData( el::base::type::ostream_t& os ) const
-    {
-        // Save stream state
-        std::ios save( NULL );
-        save.copyfmt( os );
-
-        FrameTimerData data = m_frames[0];
-
-        os << std::setprecision( 2 ) << std::fixed;
-
-        os << "Timer data for frame " << data.numFrame << std::endl;
-        {
-            long renderRelStart = Core::Timer::getIntervalMicro( data.frameStart, data.renderData.renderStart );
-            long renderRelEnd   = Core::Timer::getIntervalMicro( data.frameStart, data.renderData.renderEnd );
-            long renderTime     = Core::Timer::getIntervalMicro( data.renderData.renderStart, data.renderData.renderEnd );
-            Scalar fps    = 1.f / Core::Timer::getIntervalSeconds( data.renderData.renderStart, data.renderData.renderEnd );
-            // FIXME(Charly): Assert disabled because of a difference of 1 that occurs sometimes
-            //        CORE_ASSERT(renderTime == renderRelEnd - renderRelStart, "Timings are inconsitent");
-            os << "\tRendering  : " << renderRelStart << " -> " << renderRelEnd << " : " << renderTime << " µs | "
-               << fps << " updates per second" << std::endl;
-        }
-        {
-            long tasksRelStart = Core::Timer::getIntervalMicro( data.frameStart, data.tasksStart );
-            long tasksRelEnd   = Core::Timer::getIntervalMicro( data.frameStart, data.tasksEnd );
-            long tasksTime     = Core::Timer::getIntervalMicro( data.tasksStart, data.tasksEnd );
-            Scalar fps   = 1.f / Core::Timer::getIntervalSeconds( data.tasksStart, data.tasksEnd );
-            // FIXME(Charly): Assert disabled because of a difference of 1 that occurs sometimes
-            //        CORE_ASSERT(tasksTime == tasksRelEnd - tasksRelStart, "Timings are inconsitent");
-            os << "\tTasks      : " << tasksRelStart << " -> " << tasksRelEnd << " : " << tasksTime << " µs | "
-               << fps << " updates per second" << std::endl;
-        }
-        {
-            long frameRelStart = Core::Timer::getIntervalMicro( data.frameStart, data.frameStart );
-            long frameRelEnd =   Core::Timer::getIntervalMicro( data.frameStart, data.frameEnd );
-            long frameTime =     Core::Timer::getIntervalMicro( data.frameStart, data.frameEnd );
-            Scalar fps  =   1.f / Core::Timer::getIntervalSeconds( data.frameStart, data.frameEnd );
-            os << "\tTotal time : " << frameRelStart << " -> " << frameRelEnd << " : " << frameTime << " µs | "
-               << fps << " fps" << std::endl;
-        }
-        os << " =========   =========";
-
-        // Restore stream state
-        os.copyfmt( save );
-    }
-
-    void LoggableFrameTimerData::printAverageTimerData( el::base::type::ostream_t& os ) const
-    {
-        // Save stream state
-        std::ios save( NULL );
-        save.copyfmt( os );
-
-        long sumRender = 0;
-        long sumTasks = 0;
-        long sumFrame = 0;
-        long sumInterFrame = 0;
-        for ( uint i = 0; i < m_frames.size(); ++i )
-        {
-            sumTasks += Core::Timer::getIntervalMicro( m_frames[i].tasksStart, m_frames[i].tasksEnd );
-            sumRender += Core::Timer::getIntervalMicro( m_frames[i].renderData.renderStart, m_frames[i].renderData.renderEnd );
-            sumFrame += Core::Timer::getIntervalMicro( m_frames[i].frameStart, m_frames[i].frameEnd );
-
-            if ( i > 0 )
+            long reStart = Ra::Core::Timer::getIntervalMicro(frameStart, renderData.renderStart);
+            long reEnd = Ra::Core::Timer::getIntervalMicro(frameStart, renderData.renderEnd);
+            ostream << "\tevents: " << evStart << " " << evEnd << " " << evEnd - evStart << "\n";
+            ostream << "\ttasks: " << taStart << " " << taEnd << " " << taEnd - taStart << "\n";
+            ostream << "\t{" << "\n";
+            for (const auto& tData : taskData)
             {
-                sumInterFrame +=  Core::Timer::getIntervalMicro( m_frames[i - 1].frameStart, m_frames[i].frameEnd );
+                long tadaStart = Ra::Core::Timer::getIntervalMicro(frameStart, tData.start);
+                long tadaEnd = Ra::Core::Timer::getIntervalMicro(frameStart, tData.end);
+                ostream << "\t\t" << tData.taskName << "("<<tData.threadId<<"): " << tadaStart << " " << tadaEnd << " " << tadaEnd - tadaStart
+                        << "\n";
             }
+            ostream << "\t}" << "\n";
+            ostream << "\trender: " << reStart << " " << reEnd << " " << reEnd - reStart << "\n";
         }
-
-        const uint N = m_frames.size();
-
-        os << std::setprecision( 2 ) << std::fixed;
-        os << "Average timer data : frames " << m_frames.front().numFrame << " to " << m_frames.back().numFrame << std::endl;
-        os << "\tAverage render time : " << sumRender / N << " µs (" << N * 1000000.f / float(
-               sumRender ) << " updates per second)" << std::endl;
-        os << "\tAverage tasks time  : " << sumTasks / N << " µs (" << N * 1000000.f / float(
-               sumTasks ) << " updates per second)" << std::endl;
-        os << "\tAverage frame time  : " << sumFrame / N << " µs (" << N * 1000000.f / float(
-               sumFrame ) << " max fps)" << std::endl;
-        os << "\tAverage framerate   : " << ( N - 1 ) * 1000000.f / float( sumInterFrame ) << " fps";
-
-        // Restore stream state
-        os.copyfmt( save );
-
+        ostream<<"}"<<"\n";
+        ostream<<std::endl;
     }
-#endif
-
 }

--- a/src/GuiBase/TimerData/FrameTimerData.hpp
+++ b/src/GuiBase/TimerData/FrameTimerData.hpp
@@ -1,6 +1,8 @@
 #ifndef RADIUMENGINE_FRAME_TIMER_DATA_HPP
 #define RADIUMENGINE_FRAME_TIMER_DATA_HPP
 
+#include <GuiBase/RaGuiBase.hpp>
+
 #include <iostream>
 #include <iomanip>
 
@@ -13,7 +15,7 @@ namespace Ra
 {
 
     /// This struct holds all timings for one frame of the engine.
-    struct FrameTimerData
+    struct RA_GUIBASE_API FrameTimerData
     {
         uint numFrame;
         Core::Timer::TimePoint frameStart;

--- a/src/GuiBase/TimerData/FrameTimerData.hpp
+++ b/src/GuiBase/TimerData/FrameTimerData.hpp
@@ -15,7 +15,7 @@ namespace Ra
     /// This struct holds all timings for one frame of the engine.
     struct FrameTimerData
     {
-        int numFrame;
+        uint numFrame;
         Core::Timer::TimePoint frameStart;
         Core::Timer::TimePoint eventsStart;
         Core::Timer::TimePoint eventsEnd;
@@ -24,6 +24,8 @@ namespace Ra
         Core::Timer::TimePoint frameEnd;
         Engine::Renderer::TimerData renderData;
         std::vector<Core::TaskQueue::TimerData> taskData;
+
+        void print(std::ostream& ostream) const;
     };
 
 #if 0

--- a/src/GuiBase/Viewer/Gizmo/Gizmo.hpp
+++ b/src/GuiBase/Viewer/Gizmo/Gizmo.hpp
@@ -64,7 +64,7 @@ namespace Ra
             virtual void setInitialState(const Engine::Camera& cam, const Core::Vector2& initialXY) = 0;
 
             /// Called when the mose movement is recorder with the camera parameters and the current pixel coordinates.
-            virtual Core::Transform mouseMove(const Engine::Camera& cam, const Core::Vector2& nextXY) = 0;
+            virtual Core::Transform mouseMove(const Engine::Camera& cam, const Core::Vector2& nextXY, bool stepped = false) = 0;
 
         protected:
             Core::Transform m_worldTo;      //! World to local space where the transform lives.

--- a/src/GuiBase/Viewer/Gizmo/GizmoManager.cpp
+++ b/src/GuiBase/Viewer/Gizmo/GizmoManager.cpp
@@ -126,7 +126,7 @@ namespace Ra
                 Core::Vector2 currentXY(event->x(), event->y());
                 // const Engine::Camera& cam = *static_cast<Viewer*>(parent())->getCameraInterface()->getCamera();
                 const Engine::Camera& cam = CameraInterface::getCameraFromViewer(parent());
-                Core::Transform newTransform = currentGizmo()->mouseMove(cam, currentXY);
+                Core::Transform newTransform = currentGizmo()->mouseMove(cam, currentXY, event->modifiers().testFlag( Qt::ControlModifier ) );
                 setTransform( newTransform );
             }
             return (currentGizmo() != nullptr);

--- a/src/GuiBase/Viewer/Gizmo/RotateGizmo.cpp
+++ b/src/GuiBase/Viewer/Gizmo/RotateGizmo.cpp
@@ -107,7 +107,7 @@ namespace Ra
 
         Core::Transform RotateGizmo::mouseMove(const Engine::Camera& cam, const Core::Vector2& nextXY, bool stepped)
         {
-            static const float step = M_PI / 10;
+            static const float step = Ra::Core::Math::Pi / 10.f;
             if (m_selectedAxis >= 0)
             {
                 const Core::Vector3 origin =  m_transform.translation();

--- a/src/GuiBase/Viewer/Gizmo/RotateGizmo.cpp
+++ b/src/GuiBase/Viewer/Gizmo/RotateGizmo.cpp
@@ -88,6 +88,7 @@ namespace Ra
 
         void RotateGizmo::selectConstraint(int drawableIdx)
         {
+            int oldAxis = m_selectedAxis;
             m_selectedAxis = -1;
             if (drawableIdx >= 0)
             {
@@ -97,15 +98,20 @@ namespace Ra
                     m_selectedAxis = int(found - m_renderObjects.begin());
                 }
             }
+            if (m_selectedAxis != oldAxis)
+            {
+                m_start = false;
+                m_stepped = false;
+            }
         }
 
-        Core::Transform RotateGizmo::mouseMove(const Engine::Camera& cam, const Core::Vector2& nextXY)
+        Core::Transform RotateGizmo::mouseMove(const Engine::Camera& cam, const Core::Vector2& nextXY, bool stepped)
         {
+            static const float step = M_PI / 10;
             if (m_selectedAxis >= 0)
             {
                 const Core::Vector3 origin =  m_transform.translation();
                 Core::Vector3 rotationAxis = Core::Vector3::Unit(m_selectedAxis);
-
 
                 // Decompose the current transform's linear part into rotation and scale
                 Core::Matrix3 rotationMat;
@@ -116,6 +122,14 @@ namespace Ra
                 {
                     rotationAxis = rotationMat*rotationAxis;
                 }
+                rotationAxis.normalize();
+
+                if (!m_start)
+                {
+                    m_start = true;
+                    m_totalAngle = 0;
+                    m_initialRot = rotationMat;
+                }
 
                 // Project the clicked points against the plane defined by the rotation circles.
                 std::vector<Scalar> hits1, hits2;
@@ -124,6 +138,7 @@ namespace Ra
                 bool hit1 = Core::RayCast::vsPlane(rayToFirstClick,   m_worldTo * origin, m_worldTo * rotationAxis, hits1);
                 bool hit2 = Core::RayCast::vsPlane(rayToCurrentClick, m_worldTo * origin, m_worldTo * rotationAxis, hits2);
 
+                Core::Vector2 nextXY_ = nextXY;
                 if (hit1 && hit2)
                 {
                     // Do the calculations relative to the circle center.
@@ -138,11 +153,28 @@ namespace Ra
                     Scalar angle = Core::Math::sign(c.dot(m_worldTo * rotationAxis)) * std::atan2(c.norm(),d);
 
                     // Apply rotation.
-                    auto newRot = Core::AngleAxis(angle, rotationAxis) * rotationMat;
-                    m_transform.fromPositionOrientationScale(origin, newRot, scaleMat.diagonal() );
-
+                    if (stepped)
+                    {
+                        angle = int(angle/step)*step;
+                        if (angle == 0)
+                        {
+                            nextXY_ = m_initialPix;
+                        }
+                        if (!m_stepped)
+                        {
+                            float diff = m_totalAngle - int(m_totalAngle/step)*step;
+                            angle -= diff;
+                        }
+                    }
+                    m_stepped = stepped;
+                    m_totalAngle += angle;
+                    if (angle != 0)
+                    {
+                        auto newRot = Core::AngleAxis( angle, rotationAxis ) * rotationMat;
+                        m_transform.fromPositionOrientationScale( origin, newRot, scaleMat.diagonal() );
+                    }
                 }
-                m_initialPix = nextXY;
+                m_initialPix = nextXY_;
             }
             return m_transform;
         }

--- a/src/GuiBase/Viewer/Gizmo/RotateGizmo.hpp
+++ b/src/GuiBase/Viewer/Gizmo/RotateGizmo.hpp
@@ -16,10 +16,14 @@ namespace Ra
             virtual void updateTransform( Gizmo::Mode mode, const Core::Transform &worldTo, const Core::Transform& t ) override;
             virtual void selectConstraint( int drawableIndex ) override;
             virtual void setInitialState( const Engine::Camera& cam, const Core::Vector2& initialXY) override;
-            virtual Core::Transform mouseMove( const Engine::Camera& cam, const Core::Vector2& nextXY) override;
+            virtual Core::Transform mouseMove(const Engine::Camera& cam, const Core::Vector2& nextXY, bool stepped = false) override;
         private:
             Core::Vector2 m_initialPix;
             int m_selectedAxis;
+            bool m_start;
+            bool m_stepped;
+            float m_totalAngle;
+            Core::Matrix3 m_initialRot;
         };
     }
 }

--- a/src/GuiBase/Viewer/Gizmo/TranslateGizmo.cpp
+++ b/src/GuiBase/Viewer/Gizmo/TranslateGizmo.cpp
@@ -137,11 +137,11 @@ namespace Ra
         }
 
 
-        Core::Transform TranslateGizmo::mouseMove(const Engine::Camera& cam, const Core::Vector2& nextXY)
+        Core::Transform TranslateGizmo::mouseMove(const Engine::Camera& cam, const Core::Vector2& nextXY, bool stepped)
         {
+            static const float step = 0.2;
             if ( m_selectedAxis >= 0)
             {
-
                 const Core::Vector3 origin = m_transform.translation();
                 Core::Vector3 translateDir =  m_mode == LOCAL ?
                             Core::Vector3(m_transform.rotation() * Core::Vector3::Unit(m_selectedAxis)):
@@ -159,7 +159,15 @@ namespace Ra
                 Ra::Core::Vector3 endPoint;
                 if (findPointOnAxis( cam, origin, translateDir, m_initialPix + nextXY, endPoint ))
                 {
-                    m_transform.translation() = m_initialTrans + endPoint - m_startPoint;
+                    if (stepped)
+                    {
+                        const Ra::Core::Vector3 tr = endPoint - m_startPoint;
+                        m_transform.translation() = m_initialTrans + int(tr.norm()/step)*step * tr.normalized();
+                    }
+                    else
+                    {
+                        m_transform.translation() = m_initialTrans + endPoint - m_startPoint;
+                    }
                 }
 
             }

--- a/src/GuiBase/Viewer/Gizmo/TranslateGizmo.hpp
+++ b/src/GuiBase/Viewer/Gizmo/TranslateGizmo.hpp
@@ -15,7 +15,7 @@ namespace Ra
             virtual void updateTransform( Gizmo::Mode mode, const Core::Transform& worldTo, const Core::Transform& t ) override;
             virtual void selectConstraint( int drawableIndex ) override;
             virtual void setInitialState( const Engine::Camera& cam, const Core::Vector2& initialXY) override;
-            virtual Core::Transform mouseMove( const Engine::Camera& cam, const Core::Vector2& nextXY) override;
+            virtual Core::Transform mouseMove( const Engine::Camera& cam, const Core::Vector2& nextXY, bool stepped = false) override;
         private:
             Ra::Core::Vector3 m_startPoint;
             Ra::Core::Vector3 m_initialTrans;

--- a/src/Tests/CoreTests/Algebra/AlgebraTests.hpp
+++ b/src/Tests/CoreTests/Algebra/AlgebraTests.hpp
@@ -38,7 +38,7 @@ namespace RaTests
             Ra::Core::QuaternionUtils::getSwingTwist(qr, qs, qt);
 
             RA_UNIT_TEST (qr.isApprox( qs * qt ), "Swing decomposition fail.");
-            RA_UNIT_TEST(Ra::Core::AngleAxis(qt).axis() == Ra::Core::Vector3::UnitZ(), "Twist should be around z");
+            RA_UNIT_TEST(Ra::Core::AngleAxis(qt).axis().isApprox(Ra::Core::Vector3::UnitZ()), "Twist should be around z");
             RA_UNIT_TEST(Ra::Core::AngleAxis(qs).axis().dot(Ra::Core::Vector3::UnitZ()) == 0 , "Swing should be in xy");
 
         }


### PR DESCRIPTION
This changelist includes a lot of fixes that I backported from my own branches. 

## New functions
### Core 
* added `lerp`  (type-generic) and `slerp` (for unitary vectors). 
* a new macro in coremacros allows to distinguish between RelWithDebInfo and Release build
* added a function to extract the edge list from a triangle mesh without having to build a DCEL
* polyline projection now implements the continuous isoparam  projection cased on cotangents.
* added color scattering (from @mauriziokovacic )

### Engine
* added a new end-of-frame signal

### Animation & Skinning
* added `getBoneIdx` to get the bone index of a given animation RO. 
* animation ROs actually display their bone index in the name.
* animation now outputs the current animation time
* skinning data now has a frame counter
### Ui / Main app
* gizmos stepping : this is from @hoshiryu , it allows precise steps on the gizmos.
* main app now exports frames in a dedicated folder. It's also now possible to export the task graph (in DOT) and the task timings ( in a JSON-like structure) on stdout.
* main app now have a command line option to start only on a certain number of threads
* main app now has a button to re-fit the camera to the scene

## Fixes
* Skinning plugin is now building with qt 5.7 (the prototype for `QAction` required a pointer).
* Task queue assert messages were improved
* Removed the stale BVH code which was creating a memory leak.
* Fixed Variational Shape Approximation algorithm (ported from @mauriziokovacic )
* Windows build : re-enable RTTI to account for globjec'ts use of `dynamic_cast`. 



