### PR TITLE
Fix missing faces when loading quad meshes

### DIFF
--- a/src/IO/AssimpLoader/AssimpFileLoader.cpp
+++ b/src/IO/AssimpLoader/AssimpFileLoader.cpp
@@ -50,6 +50,7 @@ namespace Ra {
 
             const aiScene *scene = m_importer.ReadFile( fileData->getFileName(),
                                                         aiProcess_GenSmoothNormals      |
+                                                        aiProcess_Triangulate           |
                                                         aiProcess_SortByPType           |
                                                         aiProcess_FixInfacingNormals    |
                                                         aiProcess_CalcTangentSpace      |


### PR DESCRIPTION
Due to unwanted side effect when disabling automatic triangulation in assimp loader.
Fixes #228